### PR TITLE
Fixes #95 - Use #chooseDirectoryFrom:  to preselect the location, and not pick the title.

### DIFF
--- a/Iceberg.package/IceCloneRepositoryModel.class/instance/changeLocation.st
+++ b/Iceberg.package/IceCloneRepositoryModel.class/instance/changeLocation.st
@@ -1,4 +1,4 @@
 actions
 changeLocation
-	(UIManager default chooseDirectory: self location) 
+	(UIManager default chooseDirectoryFrom: self location) 
 		ifNotNil: [ :fileReference | self location: fileReference ]


### PR DESCRIPTION
`#chooseDirectory:`'s argument is the window title, not the location.