### PR TITLE
Fix branch in download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is still a prototype and is not yet ready for production, but you are invit
 ```
 Metacello new
   baseline: 'Iceberg';
-  repository: 'github://npasserini/iceberg:stable';
+  repository: 'github://npasserini/iceberg';
   load.
 ```
 


### PR DESCRIPTION
Replace download from branch 'stable' to default 'master' branch. Otherwise people will load old versions.