### PR TITLE
Change clone URL so it is easy to remember

### DIFF
--- a/Iceberg.package/IceCloneRepositoryModel.class/instance/initializeWidgets.st
+++ b/Iceberg.package/IceCloneRepositoryModel.class/instance/initializeWidgets.st
@@ -1,7 +1,7 @@
 initialization
 initializeWidgets
 	remoteUrlLabel := self newLabel label: 'Remote URL'.
-	remoteUrl := self newTextInput text: 'git@github.com:'; autoAccept: true.
+	remoteUrl := self newTextInput text: 'git@github.com:user/project.git'; autoAccept: true.
 	self focusOrder add: remoteUrl.
 
 	super initializeWidgets.


### PR DESCRIPTION
Change clone URL in dialog from 'git@github.com:' into 'git@github.com:user/project.git'
so the dialog is easy to fill out/the format is easier to remember