### PR TITLE
Fix #862

### DIFF
--- a/scripts/preLoading.st
+++ b/scripts/preLoading.st
@@ -3,7 +3,7 @@ LGitLibrary shutDown: true.
 
 "Unregister all iceberg repository adapters since we are going to unload all code related to it.
 Otherwise obsolete instances will stay".
-IceMetacelloRepositoryAdapter allInstances do: #unregister
+IceMetacelloRepositoryAdapter allInstances do: #unregister.
 
 "Remove iceberg from system (so I can reload it)"
 MetacelloPharoPlatform select.


### PR DESCRIPTION
Unregister all iceberg repository adapters since we are going to unload all code related to it.
Otherwise obsolete instances will stay"