### PR TITLE
Fix #940 Installing new Iceberg should bootstrap Pharo

### DIFF
--- a/scripts/updateIceberg.st
+++ b/scripts/updateIceberg.st
@@ -49,4 +49,4 @@ Metacello new
     repository: 'filetree://./';
     load.
 
-(Smalltalk at: #IcePharoPlugin) new addPharoProjectToIceberg
+(Smalltalk at: #IcePharoPlugin) addPharoProjectToIceberg


### PR DESCRIPTION
Fix #940 Installing new Iceberg should bootstrap Pharo