### PR TITLE
847-Move-tags-under-remotes-in-Repository-view

### DIFF
--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/repositoryModelsByGroup.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/repositoryModelsByGroup.st
@@ -12,12 +12,6 @@ repositoryModelsByGroup
 			select: [ :each | each entity isLocal ]
 			thenCollect: [ :each | IceTipTreeBranch on: each ]);
 		yourself.
-	"Tags group"
-	(IceTipTreeRepositoryGroup on: self)
-		name: 'Tags';
-		icon: (self iconNamed: #glamorousBookmark);
-		children: (tags collect: [ :each | IceTipTreeTag on: each ]);
-		yourself.
 	"Remotes group"
 	(IceTipTreeRepositoryGroup on: self)
 		name: 'Remotes';
@@ -32,5 +26,11 @@ repositoryModelsByGroup
 						and: [ each entity remoteName = eachRemote name ] ]
 					thenCollect: [ :each | IceTipTreeBranch on: each ]);
 				yourself	]);
+		yourself.
+	"Tags group"
+	(IceTipTreeRepositoryGroup on: self)
+		name: 'Tags';
+		icon: (self iconNamed: #glamorousBookmark);
+		children: (tags collect: [ :each | IceTipTreeTag on: each ]);
 		yourself.
 	}


### PR DESCRIPTION
Swap remotes and tags in repository browser.

In general we have less remotes than tags for big repos.It wake it easier to work on big repos like that.

Fixes #847