### PR TITLE
1099-Gitlab-integration-should-manage-non-default-port

### DIFF
--- a/Iceberg-Pharo6.package/MCGitlabRepository.extension/instance/scpUrl.st
+++ b/Iceberg-Pharo6.package/MCGitlabRepository.extension/instance/scpUrl.st
@@ -1,0 +1,6 @@
+*Iceberg-Pharo6
+sshPort
+	"In pharo 6 we do not have the code to be able to load gitlab with non default ssh port projects. So we return nil so that #scpUrl does not break."
+
+	^ nil
+	

--- a/Iceberg-Tests.package/MCGitlabRepositoryIcebergExtensionsTest.class/instance/testScpUrlForSelfHostedGitlabWithNonDefaultSSHPort.st
+++ b/Iceberg-Tests.package/MCGitlabRepositoryIcebergExtensionsTest.class/instance/testScpUrlForSelfHostedGitlabWithNonDefaultSSHPort.st
@@ -1,0 +1,7 @@
+running
+testScpUrlForSelfHostedGitlabWithNonDefaultSSHPort
+	| repository |
+	SystemVersion current major <= 6 ifTrue: [ self skip ].
+
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:1234:pharo-project/pharo'.
+	self assert: repository scpUrl equals: 'ssh://git@git.pharo.org:1234/pharo-project/pharo.git'

--- a/Iceberg.package/MCGitlabRepository.extension/instance/scpUrl.st
+++ b/Iceberg.package/MCGitlabRepository.extension/instance/scpUrl.st
@@ -1,3 +1,7 @@
 *Iceberg
 scpUrl
-	^ 'git@<1s>:<2s>.git' expandMacrosWith: self hostname with: projectPath
+	"If the sshPort is not nil it means that we have a non default ssh port. Thus we need to add `ssh://` and th port number to the scheme"
+
+	^ self sshPort
+		ifNil: [ 'git@<1s>:<2s>.git' expandMacrosWith: self hostname with: projectPath ]
+		ifNotNil: [ :port | 'ssh://git@<1s>:<2s>/<3s>.git' expandMacrosWith: self hostname with: port with: projectPath ]


### PR DESCRIPTION
Add possibility to clone project from self hosted gitlab with non default ssh port  via the Metacello integration.

Fixes #1099

/!\ This needs https://github.com/pharo-project/pharo/pull/2041 before it can work