### PR TITLE
1124-Loading-of-Iceberg-is-broken-because-of-Commander

### DIFF
--- a/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/commander..st
+++ b/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/commander..st
@@ -4,5 +4,5 @@ commander: spec
 		baseline: 'Commander' 
 		with: [ 
 			spec 
-				repository: 'github://pharo-ide/Commander:v0.7.1';
+				repository: 'github://pharo-ide/Commander:v0.7.1/src';
 				loads: #('Core' 'AllActivators' 'Commander-SpecSupport') ]


### PR DESCRIPTION
Commander is now in the src subdirectory.

Fixes #1124