### PR TITLE
1155-Disable-merge-warning

### DIFF
--- a/Iceberg.package/IceCommitish.class/instance/validateCanMerge.st
+++ b/Iceberg.package/IceCommitish.class/instance/validateCanMerge.st
@@ -2,9 +2,6 @@ validating
 validateCanMerge
 
 	| imageCommit headCommit mergeCommit |
-	self repository isModified
-		ifTrue: [ Warning signal: 'Experimental Feature: merge when there is a dirty working copy. Could cause a loss of your local changes. Please commit before merge.' ].
-	
 	imageCommit := self repository workingCopy referenceCommit.
 	headCommit := self repository headCommit.
 	mergeCommit := self commit.


### PR DESCRIPTION
Remove merge warning since we have it for month now without complain about it.

Fixes #1155