### PR TITLE
1185-Improve-UX-of-merge-dialog

### DIFF
--- a/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/branchModels.st
+++ b/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/branchModels.st
@@ -1,0 +1,3 @@
+initialization
+branchModels
+	^ self model branchModels

--- a/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/newBranchListDataSource.st
+++ b/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/newBranchListDataSource.st
@@ -1,6 +1,6 @@
 initialization
 newBranchListDataSource
-	^ IceTipDataSource new 
+	^ IceTipDataSource new
 		tool: self;
-		elements: self model branchModels;
-		yourself.
+		elements: self branchModels;
+		yourself

--- a/Iceberg-TipUI.package/IceTipMergeBranchDialog.class/instance/createMergeBranchTypes.st
+++ b/Iceberg-TipUI.package/IceTipMergeBranchDialog.class/instance/createMergeBranchTypes.st
@@ -6,6 +6,7 @@ createMergeBranchTypes
 	allTypes :=  { 
 	 	(IceTipMergeBranchPanel on: self model) 
 			title: 'Local';
+			withoutHead;
 			icon: (self iconNamed: #branch);
 			yourself }, 
 	(self model remoteModels collect: [ :each | 

--- a/Iceberg-TipUI.package/IceTipMergeBranchDialog.class/instance/title.st
+++ b/Iceberg-TipUI.package/IceTipMergeBranchDialog.class/instance/title.st
@@ -1,3 +1,3 @@
 accessing
 title
-	^ 'Merge ', super title asLowercase
+	^ 'Select branch to merge into ' , self model branchName

--- a/Iceberg-TipUI.package/IceTipMergeBranchPanel.class/instance/withoutHead.st
+++ b/Iceberg-TipUI.package/IceTipMergeBranchPanel.class/instance/withoutHead.st
@@ -1,0 +1,4 @@
+accessing
+withoutHead
+	self branchesList widget dataSource elements: (self branchModels reject: #isHead).
+	self branchesList widget selectFirstVisibleRow


### PR DESCRIPTION
Improve UX of merge

- Explicit name of dialog to show the direction of the merge
- Do not show head in the local branches

Fixes #1185