### PR TITLE
1249-Remove-calls-to-deprecated-methods-

### DIFF
--- a/Iceberg-Plugin-GitHub/IceGitHubCreatePullRequestModel.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubCreatePullRequestModel.class.st
@@ -53,8 +53,7 @@ IceGitHubCreatePullRequestModel class >> defaultSpec [
 								row2 
 									add: #baseForkList;
 									add: #baseBranchList ] ] ] height: 25 * World displayScaleFactor;
-				newRow: [:row | row add: #bodyLabel width: 80 * World displayScaleFactor; add: #bodyPanel ];
-				add: #addButton height: self buttonHeight  ];
+				newRow: [:row | row add: #bodyLabel width: 80 * World displayScaleFactor; add: #bodyPanel ] ];
 		yourself
 ]
 
@@ -90,16 +89,6 @@ IceGitHubCreatePullRequestModel >> accept [
 		acceptBlock cull: self createPullRequest ].
 	
 	self window delete
-]
-
-{ #category : #'accessing ui' }
-IceGitHubCreatePullRequestModel >> addButton [
-	^ addButton
-]
-
-{ #category : #'accessing ui' }
-IceGitHubCreatePullRequestModel >> addButton: anObject [
-	addButton := anObject
 ]
 
 { #category : #accessing }
@@ -287,6 +276,19 @@ IceGitHubCreatePullRequestModel >> initialExtent [
 ]
 
 { #category : #initialization }
+IceGitHubCreatePullRequestModel >> initializeDialogWindow: aDialogWindowPresenter [
+	aDialogWindowPresenter
+		addButton: 'Create pull request'
+			do: [ :presenter | 
+			self accept.
+			presenter close ];
+		addButton: 'Cancel'
+			do: [ :presenter | 
+			presenter triggerCancelAction.
+			presenter close ]
+]
+
+{ #category : #initialization }
 IceGitHubCreatePullRequestModel >> initializePresenter [
 	super initializePresenter.
 	self titlePanel text: self branch shortname.
@@ -329,14 +331,11 @@ IceGitHubCreatePullRequestModel >> initializeWidgets [
 	baseBranchList := self newDropList.
 	bodyLabel := self newLabel.
 	bodyPanel := self newText autoAccept: true.
-	addButton := self newButton.
 		
 	titleLabel label: 'Title'.
 	headLabel label: 'From (Head)'.
 	baseLabel label: 'To (Base)'.
 	bodyLabel label: 'Comment'.
-	addButton label: 'Create pull request'.
-	addButton action: [ self accept ].
 	
 	self focusOrder 
 		add: titlePanel;
@@ -344,8 +343,7 @@ IceGitHubCreatePullRequestModel >> initializeWidgets [
 		add: headBranchList;
 		add: baseForkList;
 		add: baseBranchList;
-		add: bodyPanel;
-		add: addButton
+		add: bodyPanel
 ]
 
 { #category : #private }

--- a/Iceberg-Plugin-GitHub/IceGitHubCreatePullRequestModel.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubCreatePullRequestModel.class.st
@@ -292,20 +292,20 @@ IceGitHubCreatePullRequestModel >> initializePresenter [
 	self titlePanel text: self branch shortname.
 	self headForkList
 		items: self availableRemotes;
-		displayBlock: [ :each | each owner, '/', each projectName ];
-		setSelectedItem: self headRemote.
-	self headBranchList 
+		displayBlock: [ :each | each owner , '/' , each projectName ];
+		selectedItem: self headRemote.
+	self headBranchList
 		items: self availableBranchNames;
 		displayBlock: [ :each | each ];
-		setSelectedItem: self defaultHeadBranchName.
+		selectedItem: self defaultHeadBranchName.
 	self baseForkList
 		items: self availableRemotes;
-		displayBlock: [ :each | each owner, '/', each projectName ];
-		setSelectedItem: self baseRemote.
-	self baseBranchList 
+		displayBlock: [ :each | each owner , '/' , each projectName ];
+		selectedItem: self baseRemote.
+	self baseBranchList
 		items: self availableBranchNames;
 		displayBlock: [ :each | each ];
-		setSelectedItem: self defaultBaseBranchName.
+		selectedItem: self defaultBaseBranchName.
 	self bodyPanel text: self obtainLastCommitMessage
 ]
 

--- a/Iceberg-Plugin-GitHub/IceGitHubNewBranchFromIssuePanel.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubNewBranchFromIssuePanel.class.st
@@ -90,22 +90,21 @@ IceGitHubNewBranchFromIssuePanel >> initializeFocusOrder [
 { #category : #initialization }
 IceGitHubNewBranchFromIssuePanel >> initializeWidgetsContents [
 	spacePanel := PanelMorph new asSpecAdapter.
-	
+
 	self initializeCurrentBranchLabel.
-	
+
 	remotePanel := self instantiate: IceTipSelectRemotePresenter on: self selectRemoteModel.
-	remotePanel remoteList whenSelectedItemChanged: [ :remoteModel | 
-		self useRemote: remoteModel  ].
+	remotePanel remoteList whenSelectedItemChangedDo: [ :remoteModel | self useRemote: remoteModel ].
 
 	branchLabel := self newLabel label: 'Issue number:'.
 	issueNumberText := self newTextInput
-		ghostText: 'e.g., 123';
+		placeholder: 'e.g., 123';
 		autoAccept: true.
 	issueLabel := self newLabel label: 'Title:'.
 	issueText := self newTextInput
-		ghostText: 'e.g., 123-github-issue';
+		placeholder: 'e.g., 123-github-issue';
 		autoAccept: true.
-		
+
 	issueNumberText whenBuiltDo: [ :w | w widget wrapFlag: false ].
 	issueText
 		whenBuiltDo: [ :w | 

--- a/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
@@ -39,7 +39,7 @@ IceGitHubNewPullRequestAction >> basicExecute [
 				actionOnClick: [ self class environment at: #WebBrowser ifPresent: [ :webBrowser | webBrowser openOn: url ] ifAbsent: [ self inform: ('Cannot open "{1}" because the project WebBrowser is not present by default in Pharo 6.' format: { url }) ]  ] ]
 				on: IceGitHubError
 				do: [ :e | self reportError: e ] ];
-		openModalWithSpec
+		openDialogWithSpec
 ]
 
 { #category : #private }

--- a/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
@@ -30,7 +30,6 @@ IceGitHubNewPullRequestAction >> basicExecute [
 		repository: self repository
 		credentials: self credentials
 		headRemote: remote)
-		setModal: true;
 		onAccept: [ :pullRequest | 
 			[ | pullRequestDatas url |
 			pullRequestDatas := pullRequest send.
@@ -40,7 +39,7 @@ IceGitHubNewPullRequestAction >> basicExecute [
 				actionOnClick: [ self class environment at: #WebBrowser ifPresent: [ :webBrowser | webBrowser openOn: url ] ifAbsent: [ self inform: ('Cannot open "{1}" because the project WebBrowser is not present by default in Pharo 6.' format: { url }) ]  ] ]
 				on: IceGitHubError
 				do: [ :e | self reportError: e ] ];
-		openWithSpec
+		openModalWithSpec
 ]
 
 { #category : #private }

--- a/Iceberg-Plugin-GitHub/IceGitHubRemoveBranchesAction.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubRemoveBranchesAction.class.st
@@ -21,7 +21,6 @@ IceGitHubRemoveBranchesAction >> basicExecute [
 		during: [ self cacheAllBranches ].
 
 	IceGitHubSelectListModel new 
-		setModal: true;
 		title: ('Select branches to remove on remote {1}' format: {self remote name});
 		selectLabel: 'Remove branches';
 		items: self remoteBranches;
@@ -30,7 +29,7 @@ IceGitHubRemoveBranchesAction >> basicExecute [
 				each at: 'name'. 
 				self timeSinceLastCommit: each } ];
 		onAccept: [ :selection | self removeBranches: selection ];
-		openWithSpec
+		openModalWithSpec
 ]
 
 { #category : #private }

--- a/Iceberg-TipUI/FTTableMorph.extension.st
+++ b/Iceberg-TipUI/FTTableMorph.extension.st
@@ -2,9 +2,7 @@ Extension { #name : #FTTableMorph }
 
 { #category : #'*Iceberg-TipUI' }
 FTTableMorph >> selectFirstVisibleRow [
-	^ self selectRowIndex: (container exposedRows
-		ifNotEmpty: [ :rows | rows keys first ]
-		ifEmpty: [ 0 ]).
+	^ self selectIndex: (container exposedRows ifNotEmpty: [ :rows | rows keys first ] ifEmpty: [ 0 ])
 ]
 
 { #category : #'*Iceberg-TipUI' }

--- a/Iceberg-TipUI/IceTipBrowser.class.st
+++ b/Iceberg-TipUI/IceTipBrowser.class.st
@@ -60,6 +60,12 @@ IceTipBrowser >> initializeWidgets [
 	self whenBuiltDo: [ :ann | self addShortcutsTo: ann widget ]
 ]
 
+{ #category : #initialization }
+IceTipBrowser >> initializeWindow: aWindowPresenter [
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter windowIcon: (self iconNamed: #komitterSmalltalkhubRemote)
+]
+
 { #category : #accessing }
 IceTipBrowser >> model [
 	^ model
@@ -115,9 +121,4 @@ IceTipBrowser >> toolbar [
 { #category : #'accessing ui' }
 IceTipBrowser >> toolbar: anObject [
 	toolbar := anObject
-]
-
-{ #category : #accessing }
-IceTipBrowser >> windowIcon [
-	^ self iconNamed: #komitterSmalltalkhubRemote
 ]

--- a/Iceberg-TipUI/IceTipBrowser.class.st
+++ b/Iceberg-TipUI/IceTipBrowser.class.st
@@ -63,7 +63,10 @@ IceTipBrowser >> initializeWidgets [
 { #category : #initialization }
 IceTipBrowser >> initializeWindow: aWindowPresenter [
 	super initializeWindow: aWindowPresenter.
-	aWindowPresenter windowIcon: (self iconNamed: #komitterSmalltalkhubRemote)
+	aWindowPresenter
+		windowIcon: (self iconNamed: #komitterSmalltalkhubRemote);
+		initialExtent: self initialExtent;
+		title: self title
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipCheckoutBranchDialog.class.st
+++ b/Iceberg-TipUI/IceTipCheckoutBranchDialog.class.st
@@ -63,11 +63,6 @@ IceTipCheckoutBranchDialog >> doAccept [
 ]
 
 { #category : #accessing }
-IceTipCheckoutBranchDialog >> initialExtent [
-	^ (600@400) scaledByDisplayScaleFactor
-]
-
-{ #category : #accessing }
 IceTipCheckoutBranchDialog >> model [
 	^ model
 ]

--- a/Iceberg-TipUI/IceTipCheckoutNewBranchPanel.class.st
+++ b/Iceberg-TipUI/IceTipCheckoutNewBranchPanel.class.st
@@ -119,7 +119,7 @@ IceTipCheckoutNewBranchPanel >> initializeWidgetsContents [
 	branchLabel := self newLabel label: 'New branch'.
 	branchInputText := self newTextInput
 		autoAccept: true;
-		ghostText: 'e.g., feature/what'.
+		placeholder: 'e.g., feature/what'.
 	spacePanel := PanelMorph new asSpecAdapter
 ]
 

--- a/Iceberg-TipUI/IceTipCheckoutPreviewBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCheckoutPreviewBrowser.class.st
@@ -72,8 +72,7 @@ IceTipCheckoutPreviewBrowser >> initializeCheckoutStrategyList [
 		items: checkoutStrategies;
 		displayBlock: [ :each | each description ].
 
-	checkoutStrategyList whenSelectedItemChanged: [ :aStrategy | 
-		self model checkoutStrategy: aStrategy ]
+	checkoutStrategyList whenSelectedItemChangedDo: [ :aStrategy | self model checkoutStrategy: aStrategy ]
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipDiffPanel.class.st
+++ b/Iceberg-TipUI/IceTipDiffPanel.class.st
@@ -205,16 +205,11 @@ IceTipDiffPanel >> rightLabel: aString [
 { #category : #'event handling' }
 IceTipDiffPanel >> selectionChanged: ann [
 	| element |
-	(ann newSelectedRowIndexes reject: [ :each | each = 0 ])
+	(ann newSelectedIndexes reject: [ :each | each = 0 ])
 		ifNotEmpty: [ :indexes | 
 			element := changeList widget dataSource realElementAt: indexes first.
-			self 
-				diffContentsLeft:  element value rightContents
-				right: element value leftContents ] 
-		ifEmpty: [ 
-			self resetDiffContents ].
-	
-	
+			self diffContentsLeft: element value rightContents right: element value leftContents ]
+		ifEmpty: [ self resetDiffContents ]
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipExistingBranchPanel.class.st
+++ b/Iceberg-TipUI/IceTipExistingBranchPanel.class.st
@@ -69,13 +69,16 @@ IceTipExistingBranchPanel >> initializeBranchesList [
 		dataSource: (dataSource := self newBranchListDataSource);
 		bindKeyCombination: Character cr toAction: [ self accept ];
 		onAnnouncement: FTStrongSelectionChanged do: [ self accept ].
-	
+
 	"
 	We would prefere to have this implementation but for now we have a bug with the caches because #branchModels return the same cache used by the datasource but not #defaultBranchSelection. If we correct that later we can clean the code bellow.
 	
 	self model defaultBranchSelection ifNotNil: [ :branchModel | branchesList widget selectRowIndex: (dataSource elements indexOf: branchModel) ]."
-	
-	self model branchModels detect: #isHead ifFound: [ :head | branchesList widget selectRowIndex: (dataSource elements indexOf: head) ] ifNone: [ self model hasBranches ifTrue: [ branchesList widget selectFirstVisibleRow ] ]
+
+	self model branchModels
+		detect: #isHead
+		ifFound: [ :head | branchesList widget selectIndex: (dataSource elements indexOf: head) ]
+		ifNone: [ self model hasBranches ifTrue: [ branchesList widget selectFirstVisibleRow ] ]
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
@@ -62,26 +62,24 @@ IceTipGitProviderRepositoryPanel >> initializeWidgets [
 	userNameLabel := self newLabel label: 'Owner name'.
 	userNameInputText := self newTextInput
 		autoAccept: true;
-		ghostText: 'e.g., JohnDoe'.
+		placeholder: 'e.g., JohnDoe'.
 	projectNameLabel := self newLabel label: 'Project name'.
 	projectNameInputText := self newTextInput
 		autoAccept: true;
-		ghostText: 'e.g., MyProject'.
+		placeholder: 'e.g., MyProject'.
 
 	protocolLabel := self newLabel label: 'Protocol'.
 	protocolDropList := self newDropList.
-	
-	userNameInputText 	whenTextChanged: [ :text | 
-		projectLocation appendPath: self projectAsPathToAppend ].
-	projectNameInputText whenTextChanged: [ :text |
-		projectLocation appendPath: self projectAsPathToAppend ].
+
+	userNameInputText whenTextChangedDo: [ :text | projectLocation appendPath: self projectAsPathToAppend ].
+	projectNameInputText whenTextChangedDo: [ :text | projectLocation appendPath: self projectAsPathToAppend ].
 
 	protocolDropList
 		items: IceUrlProtocol allSubclasses;
 		displayBlock: [ :each | each description ];
-		setSelectedItem: IceUrlProtocol defaultProtocol.
-	
-	self focusOrder 
+		selectedItem: IceUrlProtocol defaultProtocol.
+
+	self focusOrder
 		add: self userNameInputText;
 		add: self projectNameInputText;
 		add: self projectLocation;

--- a/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
@@ -50,13 +50,11 @@ IceTipGitRepositoryPanel >> extractProjectName: aString [
 IceTipGitRepositoryPanel >> initializeWidgets [
 	super initializeWidgets.
 	self initializeRemoteURL.
-	self remoteInputText ghostText: 'e.g., ssh://[user@]host.xz[:port]/path/to/repo.git'.
-	
-	self remoteInputText 	whenTextChanged: [ :text |
-		self projectLocation appendPath: (self extractProjectName: text) ].
-	
-	self focusOrder 
-		add: self remoteInputText	
+	self remoteInputText placeholder: 'e.g., ssh://[user@]host.xz[:port]/path/to/repo.git'.
+
+	self remoteInputText whenTextChangedDo: [ :text | self projectLocation appendPath: (self extractProjectName: text) ].
+
+	self focusOrder add: self remoteInputText
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipHistoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipHistoryBrowser.class.st
@@ -76,29 +76,33 @@ IceTipHistoryBrowser >> initialExtent [
 
 { #category : #initialization }
 IceTipHistoryBrowser >> initializeCommitList [
-	commitList widget 
+	commitList widget
 		beResizable;
-		addColumn: (IceTipTableColumn new 
-			id: 'Timestamp';
-			action: [ :each | each timeStamp asLocalStringYMDHM ];
-			width: 110 * World displayScaleFactor;
-			yourself);
-		addColumn: (IceTipTableColumn new 
-			id: 'Commit';
-			action: #shortId;
-			width: 60 * World displayScaleFactor;
-			yourself);		
-		addColumn: (IceTipTableColumn new 
-			id: 'Author';
-			action: #author;
-			width: 150 * World displayScaleFactor;
-			yourself);		
-		addColumn: (IceTipTableColumn new 
-			id: 'Description';
-			action: #descriptionWithDecoration;
-			yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Timestamp';
+				action: [ :each | each timeStamp asLocalStringYMDHM ];
+				width: 110 * World displayScaleFactor;
+				yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Commit';
+				action: #shortId;
+				width: 60 * World displayScaleFactor;
+				yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Author';
+				action: #author;
+				width: 150 * World displayScaleFactor;
+				yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Description';
+				action: #descriptionWithDecoration;
+				yourself);
 		dataSource: self newCommitsDataSource;
-		selectRowIndex: 1
+		selectIndex: 1
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipMergeBranchDialog.class.st
+++ b/Iceberg-TipUI/IceTipMergeBranchDialog.class.st
@@ -68,11 +68,6 @@ IceTipMergeBranchDialog >> doAccept [
 ]
 
 { #category : #accessing }
-IceTipMergeBranchDialog >> initialExtent [
-	^ (600@400) scaledByDisplayScaleFactor
-]
-
-{ #category : #accessing }
 IceTipMergeBranchDialog >> model [
 	^ model
 ]

--- a/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
@@ -56,10 +56,10 @@ IceTipNewRepositoryPanel class >> title [
 { #category : #initialization }
 IceTipNewRepositoryPanel >> initializeSourceDirectory [
 	subdirectoryLabel := self newLabel label: 'Source directory'.
-	subdirectoryInputText := self newTextInput 
-		ghostText: 'e.g., src';
+	subdirectoryInputText := self newTextInput
+		placeholder: 'e.g., src';
 		autoAccept: true.
-		
+
 	subdirectoryInputText text: self defaultSubdirectory
 ]
 
@@ -67,16 +67,15 @@ IceTipNewRepositoryPanel >> initializeSourceDirectory [
 IceTipNewRepositoryPanel >> initializeWidgets [
 	super initializeWidgets.
 	self initializeSourceDirectory.
-	
+
 	projectNameLabel := self newLabel label: 'Project name'.
-	projectNameInputText := self newTextInput 
-		ghostText: 'e.g., MyProject';
+	projectNameInputText := self newTextInput
+		placeholder: 'e.g., MyProject';
 		autoAccept: true.
-	
-	projectNameInputText 	whenTextChanged: [ :text | 
-		projectLocation appendPath: text ].
-	
-	self focusOrder 
+
+	projectNameInputText whenTextChangedDo: [ :text | projectLocation appendPath: text ].
+
+	self focusOrder
 		add: self projectNameInputText;
 		add: self projectLocation;
 		add: self subdirectoryInputText;

--- a/Iceberg-TipUI/IceTipOptionDialog.class.st
+++ b/Iceberg-TipUI/IceTipOptionDialog.class.st
@@ -46,13 +46,8 @@ IceTipOptionDialog >> allTypes [
 { #category : #private }
 IceTipOptionDialog >> basicSelectionChanged: aType [
 	type := aType.
-	aType 
-		ifNotNil: [ 	
-			self title: type title.
-			self replacePanelWith: type ]
-		ifNil: [ 
-			self removeAllPanels.
-			self title: self class title ]
+	aType ifNotNil: [ self replacePanelWith: type ] ifNil: [ self removeAllPanels ].
+	self updateTitle
 ]
 
 { #category : #'accessing ui' }
@@ -179,8 +174,8 @@ IceTipOptionDialog >> replacePanelWith: aType [
 
 { #category : #private }
 IceTipOptionDialog >> selectFirst [
-	typeList widget selectRowIndex: 1.
-	self basicSelectionChanged: self allTypes first 	
+	typeList widget selectIndex: 1.
+	self basicSelectionChanged: self allTypes first
 ]
 
 { #category : #accessing }
@@ -190,9 +185,12 @@ IceTipOptionDialog >> selectedType [
 
 { #category : #private }
 IceTipOptionDialog >> selectionChanged: ann [
-	self basicSelectionChanged: (ann newSelectedRowIndexes
-		ifNotEmpty: [ :indexes |	self typeList widget dataSource realElementAt: indexes first ]
-		ifEmpty: [ nil ])
+	self basicSelectionChanged: (ann newSelectedIndexes ifNotEmpty: [ :indexes | self typeList widget dataSource realElementAt: indexes first ] ifEmpty: [ nil ])
+]
+
+{ #category : #accessing }
+IceTipOptionDialog >> title [
+	^ type ifNotNil: #title ifNil: [ self class title ]
 ]
 
 { #category : #'accessing ui' }
@@ -203,4 +201,9 @@ IceTipOptionDialog >> typeList [
 { #category : #'accessing ui' }
 IceTipOptionDialog >> typeList: anObject [
 	typeList := anObject
+]
+
+{ #category : #private }
+IceTipOptionDialog >> updateTitle [
+	self withWindowDo: [ :window | window title: self title ]
 ]

--- a/Iceberg-TipUI/IceTipOptionDialog.class.st
+++ b/Iceberg-TipUI/IceTipOptionDialog.class.st
@@ -87,7 +87,7 @@ IceTipOptionDialog >> giveFocusToNextFrom: aModel [
 
 { #category : #accessing }
 IceTipOptionDialog >> initialExtent [
-	^ (600@300) scaledByDisplayScaleFactor
+	^ (600@400) scaledByDisplayScaleFactor
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipRegisterRepositoryDialog.class.st
+++ b/Iceberg-TipUI/IceTipRegisterRepositoryDialog.class.st
@@ -55,7 +55,7 @@ IceTipRegisterRepositoryDialog >> doEdit: aRepository [
 
 { #category : #testing }
 IceTipRegisterRepositoryDialog >> isEditing [ 
-	^ repository isNil not
+	^ repository isNotNil
 ]
 
 { #category : #events }

--- a/Iceberg-TipUI/IceTipRemoteActionBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRemoteActionBrowser.class.st
@@ -31,12 +31,11 @@ IceTipRemoteActionBrowser class >> onRepositoryModel: aRepository [
 { #category : #initialization }
 IceTipRemoteActionBrowser >> initializeWidgets [
 	super initializeWidgets.
-	
-	remotePanel := self instantiate: IceTipSelectRemotePresenter on: self model. 
-	remotePanel remoteList whenSelectedItemChanged: [ :remoteModel | 
-		self moveToRemote: remoteModel  ].
-		
-	self focusOrder 
+
+	remotePanel := self instantiate: IceTipSelectRemotePresenter on: self model.
+	remotePanel remoteList whenSelectedItemChangedDo: [ :remoteModel | self moveToRemote: remoteModel ].
+
+	self focusOrder
 		add: self commitsPanel;
 		add: self actionPanel;
 		add: self remotePanel

--- a/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
@@ -61,25 +61,28 @@ IceTipRepositoriesBrowser >> initialize [
 
 { #category : #initialization }
 IceTipRepositoriesBrowser >> initializeRepositoryList [
-	repositoryList widget 
+	repositoryList widget
 		beResizable;
-		addColumn: (IceTipTableColumn new 
-			id: 'Name';
-			action: #descriptionWithDecoration;
-			width: 200;
-			yourself);
-		addColumn: (IceTipTableColumn new 
-			id: 'Status';
-			action: #status;
-			width: 150;
-			yourself);
-		addColumn: (IceTipTableColumn new 
-			id: 'Branch';
-			action: #branchName;
-			yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Name';
+				action: #descriptionWithDecoration;
+				width: 200;
+				yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Status';
+				action: #status;
+				width: 150;
+				yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Branch';
+				action: #branchName;
+				yourself);
 		dataSource: self newRepositoriesDataSource;
-		selectRowIndex: 1;
-		enableFilter: IceTipRepositoryFilter;			
+		selectIndex: 1;
+		enableFilter: IceTipRepositoryFilter;
 		explicitFunction
 ]
 
@@ -144,13 +147,9 @@ IceTipRepositoriesBrowser >> repositorySelected [
 { #category : #private }
 IceTipRepositoriesBrowser >> repositoryStrongSelection: ann [
 	| selection context |
-	
-	selection := repositoryList widget dataSource elementAt: ann selectedRowIndex.
+	selection := repositoryList widget dataSource elementAt: ann selectedIndex.
 	context := self newContextWithSelection: selection.
-	IceTipCommandStrongSelectionActivation
-		activateAllInContext: context
-		by: [ :each | each executeCommand ].		
-
+	IceTipCommandStrongSelectionActivation activateAllInContext: context by: [ :each | each executeCommand ]
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
@@ -40,12 +40,10 @@ IceTipRepositoryBrowser class >> onRepository: aRepository [
 { #category : #'event handling' }
 IceTipRepositoryBrowser >> commitishSelected: ann [
 	| selection |
-	
-	ann newSelectedRowIndexes 
-		ifNotEmpty: [ :indexes |
+	ann newSelectedIndexes
+		ifNotEmpty: [ :indexes | 
 			selection := sidebarTree widget dataSource elementAt: indexes first.
-			(selection depth = 0 or: [ selection hasChildren ]) 
-				ifTrue: [ ^ self "just refresh on leafs" ].
+			(selection depth = 0 or: [ selection hasChildren ]) ifTrue: [ ^ self	"just refresh on leafs" ].
 			historyPanel model: selection data model ]
 ]
 
@@ -116,13 +114,13 @@ IceTipRepositoryBrowser >> newSidebarTreeDataSource [
 { #category : #accessing }
 IceTipRepositoryBrowser >> refresh [
 	self rebuildToolbar.
-    self sidebarTree widget 
-        in: [ :this | 
-            this selectRowIndexes: #(). 
-            this dataSource 
-                rootForItems: self model repositoryModelsByGroup;
-                expandRoots ];
-        refresh.
+	self sidebarTree widget
+		in: [ :this | 
+			this selectIndexes: #().
+			this dataSource
+				rootForItems: self model repositoryModelsByGroup;
+				expandRoots ];
+		refresh
 ]
 
 { #category : #'private factory' }
@@ -136,12 +134,9 @@ IceTipRepositoryBrowser >> refreshWhenRepository: ann [
 { #category : #initialization }
 IceTipRepositoryBrowser >> selectCurrentBranch [
 	| index branch |
-
 	branch := self model headModel.
-	index := (sidebarTree widget dataSource 
-		indexOfElementMatching: [ :each | each isLeaf and: [ each model name = branch name ] ]).
-	sidebarTree widget selectRowIndex: index.
-	
+	index := sidebarTree widget dataSource indexOfElementMatching: [ :each | each isLeaf and: [ each model name = branch name ] ].
+	sidebarTree widget selectIndex: index
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipRepositoryTypePanel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryTypePanel.class.st
@@ -65,8 +65,8 @@ IceTipRepositoryTypePanel >> initializeProjectLocation [
 { #category : #initialization }
 IceTipRepositoryTypePanel >> initializeRemoteURL [
 	remoteLabel := self newLabel label: 'Remote URL'.
-	remoteInputText := self newTextInput 
-		ghostText: 'e.g., git@github.com:user/MyProject.git';	
+	remoteInputText := self newTextInput
+		placeholder: 'e.g., git@github.com:user/MyProject.git';
 		autoAccept: true
 ]
 

--- a/Iceberg-TipUI/IceTipSelectRemotePresenter.class.st
+++ b/Iceberg-TipUI/IceTipSelectRemotePresenter.class.st
@@ -54,14 +54,13 @@ IceTipSelectRemotePresenter >> initializeWidgets [
 	remoteList
 		items: self model remoteModels;
 		displayBlock: [ :each | each descriptionWithDecoration ].
-		
+
 	addButton := self newButton icon: self icon.
 	addButton action: [ self addRemote ].
-	
-	remoteList setSelectedItem: self model remoteModel.
-	
-	self focusOrder 
-		add: remoteList
+
+	remoteList selectedItem: self model remoteModel.
+
+	self focusOrder add: remoteList
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
+++ b/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
@@ -58,19 +58,21 @@ IceTipWorkingCopyBrowser >> initialExtent [
 
 { #category : #initialization }
 IceTipWorkingCopyBrowser >> initializePackageList [
-	packageList widget 
+	packageList widget
 		beResizable;
-		addColumn: (IceTipTableColumn new 
-			id: 'Name';
-			action: #descriptionWithDecoration;
-			yourself);
-		addColumn: (IceTipTableColumn new 
-			id: 'Status';
-			action: #statusWithDecoration;
-			yourself);		
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Name';
+				action: #descriptionWithDecoration;
+				yourself);
+		addColumn:
+			(IceTipTableColumn new
+				id: 'Status';
+				action: #statusWithDecoration;
+				yourself);
 		dataSource: self newPackagesDataSource;
-		selectRowIndex: 1;
-		enableFilter: IceTipPackageFilter;			
+		selectIndex: 1;
+		enableFilter: IceTipPackageFilter;
 		explicitFunction
 ]
 


### PR DESCRIPTION
Remove use of some deprecated methods of Spec 2 and FastTable.WARNING: This breaks the P7 compatibility, but after a talk with Pablo and Esteban we think it's probably good because Iceberg from P7 is already pretty stable.Fixes #1249