### PR TITLE
1244-Allow-to-checkout-branch-in-more-cases

### DIFF
--- a/Iceberg-TipUI/IceTipCheckoutBranchCommand.class.st
+++ b/Iceberg-TipUI/IceTipCheckoutBranchCommand.class.st
@@ -18,7 +18,7 @@ IceTipCheckoutBranchCommand class >> browserContextActivation [
 
 { #category : #testing }
 IceTipCheckoutBranchCommand class >> canBeExecutedInContext: aToolContext [
-	^ aToolContext isRepositoryOperational
+	^ aToolContext isRepositoryMissing not
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Let user checkout branch in more cases.

We should be able to checkout a branch is the sources are not here (because it might be because we are on the wrong branch) or if the repo is in detached head (because in that case you want to checkout a branch).

Fixes #1244