### PR TITLE
1257-Cannot-change-class-that-have-an-inst-var-of-the-same-name-as-a-class-inst-var-

### DIFF
--- a/Iceberg/IceClassDefinition.class.st
+++ b/Iceberg/IceClassDefinition.class.st
@@ -51,8 +51,8 @@ IceClassDefinition >> asMCDefinitionWithoutMetaSide [
 		traitComposition: mcDefinition traitCompositionString
 		classTraitComposition: mcDefinition classTraitCompositionString
 		category: mcDefinition category
-		instVarNames: mcDefinition instanceVariablesString
-		classVarNames: mcDefinition classVariablesString
+		instVarNames: mcDefinition instVarNames
+		classVarNames: mcDefinition classVarNames
 		poolDictionaryNames: mcDefinition poolDictionaries
 		classInstVarNames: #()
 		type: mcDefinition type


### PR DESCRIPTION
Do not give strings but array to MCClassDefinition.

Fixes #1257