### PR TITLE
1263 - Do not use default name in toolbar items but real command name

### DIFF
--- a/Iceberg-TipUI/IceTipToolbarActivation.class.st
+++ b/Iceberg-TipUI/IceTipToolbarActivation.class.st
@@ -32,5 +32,5 @@ IceTipToolbarActivation >> position: aPosition [
 
 { #category : #accessing }
 IceTipToolbarActivation >> toolbarName [
-	^ self commandClass defaultToolbarItemName
+	^ self menuItemName
 ]


### PR DESCRIPTION
The goal is to be able to personalize the name depending on where is the command.

Fixes #1263