### PR TITLE
1266-Iceberg-should-not-use-Spec-internals

### DIFF
--- a/Iceberg-Plugin-GitHub/IceGitHubNewBranchFromIssuePanel.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubNewBranchFromIssuePanel.class.st
@@ -109,8 +109,7 @@ IceGitHubNewBranchFromIssuePanel >> initializeWidgetsContents [
 		whenBuiltDo: [ :w | 
 			w widget wrapFlag: false.
 			w widget enabled: false ].
-	issueNumberText textHolder
-		whenChangedDo: [ :text | self validateIssue: text ]
+	issueNumberText whenTextChangedDo: [ :text | self validateIssue: text ]
 ]
 
 { #category : #'accessing ui' }

--- a/Iceberg-Plugin-Pharo/IcePharoManuscriptPlugin.class.st
+++ b/Iceberg-Plugin-Pharo/IcePharoManuscriptPlugin.class.st
@@ -9,7 +9,7 @@ NOTE: In the future we can add other fogbugz elements (like list issues, etc.), 
 Class {
 	#name : #IcePharoManuscriptPlugin,
 	#superclass : #IcePlugin,
-	#category : 'Iceberg-Plugin-Pharo-Manuscript'
+	#category : #'Iceberg-Plugin-Pharo-Manuscript'
 }
 
 { #category : #testing }

--- a/Iceberg-Plugin-Pharo/IcePharoMenuGroup.class.st
+++ b/Iceberg-Plugin-Pharo/IcePharoMenuGroup.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #IcePharoMenuGroup,
 	#superclass : #CmdMenuGroup,
-	#category : 'Iceberg-Plugin-Pharo-Core'
+	#category : #'Iceberg-Plugin-Pharo-Core'
 }
 
 { #category : #accessing }

--- a/Iceberg-Plugin-Pharo/IcePharoNewBranchFromIssuePanel.class.st
+++ b/Iceberg-Plugin-Pharo/IcePharoNewBranchFromIssuePanel.class.st
@@ -11,7 +11,7 @@ Class {
 		'issue',
 		'fetched'
 	],
-	#category : 'Iceberg-Plugin-Pharo-Manuscript'
+	#category : #'Iceberg-Plugin-Pharo-Manuscript'
 }
 
 { #category : #specs }
@@ -96,7 +96,7 @@ IcePharoNewBranchFromIssuePanel >> initializeWidgetsContents [
 		whenBuiltDo: [ :w | 
 			w widget wrapFlag: false.
 			w widget enabled: false ].
-	issueNumberText textHolder whenChangedDo: [ :text | self validateIssue: text ]
+	issueNumberText whenTextChangedDo: [ :text | self validateIssue: text ]
 ]
 
 { #category : #'accessing ui' }

--- a/Iceberg-Plugin-Pharo/IceTipNewBranchFromIssueCommand.class.st
+++ b/Iceberg-Plugin-Pharo/IceTipNewBranchFromIssueCommand.class.st
@@ -4,7 +4,7 @@ icon
 Class {
 	#name : #IceTipNewBranchFromIssueCommand,
 	#superclass : #IceTipCommand,
-	#category : 'Iceberg-Plugin-Pharo-Manuscript'
+	#category : #'Iceberg-Plugin-Pharo-Manuscript'
 }
 
 { #category : #testing }


### PR DESCRIPTION
Remove call to Spec internals.

Fixes #1266