### PR TITLE
Move Iceberg menu item from Library to Sources.

### DIFF
--- a/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
@@ -78,9 +78,9 @@ IceTipRepositoriesBrowser class >> menuCommandOn: aBuilder [
 	<worldMenu> 
 	
 	(aBuilder item: #'Iceberg')
-		order: 0.8;
+		order: 1;
 		icon: self iconForWorldMenu;
-		parent: #'Tools';
+		parent: #'Versioning';
 		keyText: 'o, i';
 		help: 'Iceberg is a set of tools that allow one to handle git repositories directly from a Pharo image.';
 		action: [ self new openWithSpec ]


### PR DESCRIPTION
Following the recent reorg of the world menu in Pharo 9 we need to move the Iceberg menu item from its current location in the Library menu to the Sources menu.