### PR TITLE
1444-Repository-Window-is-loosing-the-toolbar-when-selecting-rows

### DIFF
--- a/Iceberg-TipUI/IceTipHistoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipHistoryBrowser.class.st
@@ -168,3 +168,9 @@ IceTipHistoryBrowser >> titleForWindow [
 		ifNil: [ 'History' ]
 
 ]
+
+{ #category : #events }
+IceTipHistoryBrowser >> whenSelectionChangedDo: aBlock [ 
+	
+	commitList whenSelectionChangedDo: aBlock
+]

--- a/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
@@ -98,6 +98,8 @@ IceTipRepositoryBrowser >> initializePresenters [
 	historyPanel := self
 		instantiate: IceTipHiedraHistoryBrowser
 		on: self model headModel.
+
+	historyPanel whenSelectionChangedDo: [ self refreshCommands ].
 	historyPanel beForMerge.
 
 	self initializeSidebarTree.


### PR DESCRIPTION
RepositoryBrowser should update the Toolbar when there is a selection change

Fix #1444