### PR TITLE
1413-Metacello-options-do-not-appear-in-the-repository-view

### DIFF
--- a/Iceberg-Plugin-Metacello/IceTipMetacelloInstallCommandBuilder.class.st
+++ b/Iceberg-Plugin-Metacello/IceTipMetacelloInstallCommandBuilder.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #IceTipMetacelloInstallCommandBuilder,
+	#superclass : #Object,
+	#category : #'Iceberg-Plugin-Metacello'
+}
+
+{ #category : #builder }
+IceTipMetacelloInstallCommandBuilder >> addCommandsFor: anIceTipRepositoryModel intoGroup: aSpCommandGroup [ 
+	
+	| baselines |
+	
+	baselines := (anIceTipRepositoryModel workingCopy packageModels 
+		select: [ :each | each name beginsWith: 'BaselineOf' ])
+		sorted: [ :a :b | a name < b name ].
+		
+	
+	baselines do: [ :aPackage |
+		self addCommandsForPackage: aPackage intoGroup: aSpCommandGroup ]
+]
+
+{ #category : #builder }
+IceTipMetacelloInstallCommandBuilder >> addCommandsForPackage: aPackage intoGroup: aSpCommandGroup [ 
+	
+	| defaultBaselineCommand groupBaselineCommand baselineName |
+	
+	baselineName := aPackage name allButFirst: 'BaselineOf' size.
+	
+	defaultBaselineCommand := IceTipMetacelloInstallBaselineDefaultCommand new.
+	defaultBaselineCommand name: ('Install baseline of {1} (Default)' format: { baselineName }).
+	defaultBaselineCommand packageModel: aPackage.
+	aSpCommandGroup register: defaultBaselineCommand asSpecCommand.
+	
+	groupBaselineCommand := IceTipMetacelloInstallBaselineGroupCommand new.
+	groupBaselineCommand name: ('Install baseline of {1} ...' format: { baselineName }).
+	groupBaselineCommand packageModel: aPackage.
+	aSpCommandGroup register: groupBaselineCommand asSpecCommand
+]

--- a/Iceberg-Plugin-Metacello/IceTipRepositoriesBrowser.extension.st
+++ b/Iceberg-Plugin-Metacello/IceTipRepositoriesBrowser.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #IceTipRepositoriesBrowser }
+
+{ #category : #'*Iceberg-Plugin-Metacello' }
+IceTipRepositoriesBrowser class >> metacelloCommandsWith: presenter forRootGroup: aCommandGroup [
+
+	<extensionCommands>
+	| newGroup |
+	newGroup := CmCommandGroup forSpec
+		name: 'Metacello';
+		description: 'Metacello install operations';
+		yourself.
+	
+	(aCommandGroup commandOrGroupNamed: 'Selection') register: newGroup.
+
+	presenter selectedItem ifNotNil: [ 
+		IceTipMetacelloInstallCommandBuilder new
+			addCommandsFor: presenter selectedItem intoGroup: newGroup ]	
+
+]

--- a/Iceberg-TipUI/IceTipPackageCommand.class.st
+++ b/Iceberg-TipUI/IceTipPackageCommand.class.st
@@ -4,6 +4,9 @@ Abstract class representing commands to be applied on top of packages.
 Class {
 	#name : #IceTipPackageCommand,
 	#superclass : #IceTipCommand,
+	#instVars : [
+		'packageModel'
+	],
 	#category : #'Iceberg-TipUI-Commands'
 }
 
@@ -34,5 +37,11 @@ IceTipPackageCommand >> package [
 { #category : #accessing }
 IceTipPackageCommand >> packageModel [
 
-	^ self context packageModel
+	^ packageModel ifNil: [self context packageModel]
+]
+
+{ #category : #accessing }
+IceTipPackageCommand >> packageModel: anIceTipPackageModel [ 
+
+	packageModel := anIceTipPackageModel
 ]

--- a/Iceberg-TipUI/IceTipRepositoryModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryModel.class.st
@@ -475,6 +475,12 @@ IceTipRepositoryModel >> verifyDirectoryStructureIfMissing: aBlock [
 ]
 
 { #category : #accessing }
+IceTipRepositoryModel >> workingCopy [
+	
+	^ IceTipWorkingCopyModel on: self
+]
+
+{ #category : #accessing }
 IceTipRepositoryModel >> workingCopyDiff [
 	<noCache>
 


### PR DESCRIPTION
Adding back the Metacello options to the context menu
Fix #1413