### PR TITLE
 1451-Exception-when-creating-a-branch-from-the-repository-view

### DIFF
--- a/Iceberg-TipUI/IceTipRemoteModel.class.st
+++ b/Iceberg-TipUI/IceTipRemoteModel.class.st
@@ -9,6 +9,14 @@ Class {
 	#category : #'Iceberg-TipUI-Model'
 }
 
+{ #category : #comparing }
+IceTipRemoteModel >> = anotherModel [
+
+	self species = anotherModel species ifFalse: [ ^ false ].
+	
+	^ entity = anotherModel entity
+]
+
 { #category : #accessing }
 IceTipRemoteModel >> branches [
 	^ self entity branches


### PR DESCRIPTION
Adding equals to IceTipRemoteModel. This is used by Spec to show the correct element in the dropdown list.

Fix #1451