### PR TITLE
1450-Experimental-Feature-Warning-should-be-a-Dialog

### DIFF
--- a/Iceberg-TipUI/IceErrorVisitor.extension.st
+++ b/Iceberg-TipUI/IceErrorVisitor.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #IceErrorVisitor }
 
 { #category : #'*Iceberg-TipUI' }
+IceErrorVisitor >> visitExperimentalFeature: aWarning [
+	
+	"By default experimental features are just accepted when we are not in an interactive mode".
+	aWarning resume
+]
+
+{ #category : #'*Iceberg-TipUI' }
 IceErrorVisitor >> visitNoCommitMessage: aWarning [
 	self visitGenericError: aWarning
 ]

--- a/Iceberg-TipUI/IceExperimentalFeature.class.st
+++ b/Iceberg-TipUI/IceExperimentalFeature.class.st
@@ -1,0 +1,16 @@
+"
+Everytime an user tries to use an experimental feature, maybe the UI want to show a confirmation message. 
+
+This is useful to guarantee the correct keeping of the changes.
+"
+Class {
+	#name : #IceExperimentalFeature,
+	#superclass : #IceWarning,
+	#category : #'Iceberg-TipUI-Exceptions'
+}
+
+{ #category : #visiting }
+IceExperimentalFeature >> acceptError: aVisitor [
+
+	aVisitor visitExperimentalFeature: self
+]

--- a/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
+++ b/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
@@ -55,6 +55,22 @@ IceTipInteractiveErrorVisitor >> visitCloneRemoteNotFound: anError [
 ]
 
 { #category : #visiting }
+IceTipInteractiveErrorVisitor >> visitExperimentalFeature: aWarning [
+	| proceed |
+	
+	proceed := UIManager default
+		confirm: aWarning messageText
+		label: 'Warning!'  
+		trueChoice: 'Continue' 
+		falseChoice: 'Cancel'
+		cancelChoice: nil
+		default: false.
+	
+	proceed ifNil: [ ^ self ].
+	proceed ifTrue: [ aWarning resume ]
+]
+
+{ #category : #visiting }
 IceTipInteractiveErrorVisitor >> visitGenericError: anError [
 	
 	(IceTipErrorDialog on: anError) openDialogWithSpec

--- a/Iceberg/IceCommitish.class.st
+++ b/Iceberg/IceCommitish.class.st
@@ -289,7 +289,7 @@ IceCommitish >> validateCanMerge [
 
 	| imageCommit headCommit mergeCommit |
 	self repository isModified
-		ifTrue: [ Warning signal: 'Experimental Feature: merge when there is a dirty working copy. Could cause a loss of your local changes. Please commit before merge.' ].
+		ifTrue: [ IceExperimentalFeature signal: 'Experimental Feature: merge when there is a dirty working copy. Could cause a loss of your local changes. Please commit before merge.' ].
 	
 	imageCommit := self repository workingCopy referenceCommit.
 	headCommit := self repository headCommit.


### PR DESCRIPTION
Adding specific warning for Experimental Feature. So, the UI can handle it correctly and ask for confirmation.

Fix #1450