### PR TITLE
1454-In-Pull-window-Fetch-command-in-toolbar-ignores-the-selected-remote

### DIFF
--- a/Iceberg-TipUI/IceTipFetchInPullCommand.class.st
+++ b/Iceberg-TipUI/IceTipFetchInPullCommand.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #IceTipFetchInPullCommand,
+	#superclass : #IceTipRepositoryCommand,
+	#category : #'Iceberg-TipUI-Commands'
+}
+
+{ #category : #default }
+IceTipFetchInPullCommand class >> defaultDescription [
+
+	^ 'Fetch from the selected remote'
+]
+
+{ #category : #default }
+IceTipFetchInPullCommand class >> defaultName [
+
+	^ 'Fetch'
+]
+
+{ #category : #executing }
+IceTipFetchInPullCommand >> execute [
+
+	context model remoteModel fetch
+
+]
+
+{ #category : #accessing }
+IceTipFetchInPullCommand >> iconName [
+
+	^ #smallUpdate
+]

--- a/Iceberg-TipUI/IceTipPullBrowser.class.st
+++ b/Iceberg-TipUI/IceTipPullBrowser.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #commands }
 IceTipPullBrowser class >> buildGeneralCommandGroupWith: presenter for: aCommandGroup [
 
-	aCommandGroup register: IceTipFetchCommand forSpec
+	aCommandGroup register: IceTipFetchInPullCommand forSpec
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
Having a special command for the pull browser. Because it depends on the selected remote
Fix #1454