### PR TITLE
Inspect should unwrap to get the real object when it is a cached object

### DIFF
--- a/Iceberg-TipUI/IceTipInspectCommand.class.st
+++ b/Iceberg-TipUI/IceTipInspectCommand.class.st
@@ -36,3 +36,13 @@ IceTipInspectCommand >> iconName [
 
 	^ #glamorousInspect
 ]
+
+{ #category : #accessing }
+IceTipInspectCommand >> item [
+
+	| maybeCachedObject |
+	maybeCachedObject := super item.
+	
+	^ (maybeCachedObject respondsTo: #realObject)
+		ifTrue: [ maybeCachedObject realObject ] ifFalse: [ maybeCachedObject ]
+]


### PR DESCRIPTION
Fix #1491