### PR TITLE
Ask Credential Dialog should cancel if the window is closed.

### DIFF
--- a/Iceberg-TipUI/IceTipAbstractCredentialsModel.class.st
+++ b/Iceberg-TipUI/IceTipAbstractCredentialsModel.class.st
@@ -115,7 +115,10 @@ IceTipAbstractCredentialsModel >> initialize [
 IceTipAbstractCredentialsModel >> initializeDialogWindow: aDialogWindowPresenter [
 
 	super initializeDialogWindow: aDialogWindowPresenter.
-	self updateOkButton
+	self updateOkButton.
+
+	aDialogWindowPresenter whenClosedDo: [ accepted ifFalse: [ self cancelAskAction ] ] 
+	
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
When the cancel is executed, an exception is thrown. So if the dialog has not been accepted it should do the same on close.
Fix #1493