### PR TITLE
[Bug]: Ice Method Should Use #contextClass for Browsing

### DIFF
--- a/Iceberg-TipUI/IceMethodDefinition.extension.st
+++ b/Iceberg-TipUI/IceMethodDefinition.extension.st
@@ -3,18 +3,15 @@ Extension { #name : #IceMethodDefinition }
 { #category : #'*Iceberg-TipUI' }
 IceMethodDefinition >> browse [
 	
-	| owner |
-	owner := Smalltalk globals at: self className.
-	self classIsMeta ifTrue: [ owner := owner classSide ].
-	(owner >> name) browse
+	(self contextClass >> name) browse
 ]
 
 { #category : #'*Iceberg-TipUI' }
 IceMethodDefinition >> canBeBrowsed [
 	
-	^ Smalltalk globals at: className
-		ifPresent: [ :class | class includesSelector: name ]
-		ifAbsent: [ false ]
+	^ self contextClass
+		ifNotNil: [ :class | class includesSelector: name ]
+		ifNil: [ false ]
 ]
 
 { #category : #'*Iceberg-TipUI' }

--- a/Iceberg-TipUI/IceTipCommitCommand.class.st
+++ b/Iceberg-TipUI/IceTipCommitCommand.class.st
@@ -25,12 +25,6 @@ IceTipCommitCommand >> canBeExecuted [
 	^ self isRepositoryOperational
 ]
 
-{ #category : #execution }
-IceTipCommitCommand >> execute [
-
-	(IceTipCommitBrowser on: self repositoryModel) openWithSpec
-]
-
 { #category : #accessing }
 IceTipCommitCommand >> iconName [
 

--- a/Iceberg-TipUI/IceTipCommitCommand.class.st
+++ b/Iceberg-TipUI/IceTipCommitCommand.class.st
@@ -25,6 +25,12 @@ IceTipCommitCommand >> canBeExecuted [
 	^ self isRepositoryOperational
 ]
 
+{ #category : #execution }
+IceTipCommitCommand >> execute [
+
+	(IceTipCommitBrowser on: self repositoryModel) openWithSpec
+]
+
 { #category : #accessing }
 IceTipCommitCommand >> iconName [
 


### PR DESCRIPTION
- `#canBeBrowsed` wasn't taking into account whether we have a metaclass
- `browse` was duplicating built-in behavior