### PR TITLE
IceRepositoryProperties should have "private" method category, not "private " (with additional space)

### DIFF
--- a/Iceberg-Libgit/IceRepositoryProperties.class.st
+++ b/Iceberg-Libgit/IceRepositoryProperties.class.st
@@ -149,12 +149,12 @@ IceRepositoryProperties >> isUnborn [
 	^ false
 ]
 
-{ #category : #'private ' }
+{ #category : #private }
 IceRepositoryProperties >> properties [
 	^ properties ifNil: [ properties := Dictionary new ]
 ]
 
-{ #category : #'private ' }
+{ #category : #private }
 IceRepositoryProperties >> properties: aDictionary [
 	properties := aDictionary
 ]


### PR DESCRIPTION


Fix #1502