### PR TITLE
IceTipCheckoutMode Should Use Diff Accessor

### DIFF
--- a/Iceberg-TipUI/IceTipCheckoutModel.class.st
+++ b/Iceberg-TipUI/IceTipCheckoutModel.class.st
@@ -19,7 +19,7 @@ IceTipCheckoutModel >> checkout [
 
 	checkoutStrategy
 		committish: self commitish;
-		diff: diffModel entity.
+		diff: self diff entity.
 
 	self commitish checkout: checkoutStrategy
 ]


### PR DESCRIPTION
`#checkout` was directly referencing the inst var, which can lead to an error because it is lazily initialized.