### PR TITLE
Typo: method category "access options" should be "accessing - options"

### DIFF
--- a/Iceberg/IceCherrypicker.class.st
+++ b/Iceberg/IceCherrypicker.class.st
@@ -29,7 +29,7 @@ IceCherrypicker >> addClassDependencyOf: aIceClassDefinition [
 				yourself)
 ]
 
-{ #category : #'access options' }
+{ #category : #'accessing - options' }
 IceCherrypicker >> addDependency: anIceDependency [ 
 	self dependencies add: anIceDependency .
 ]


### PR DESCRIPTION
Fix #1512