### PR TITLE
1521-Keyboard-arrows-does-not-work-in-commit-window-after-selecting-tree

### DIFF
--- a/Iceberg-TipUI/IceTipDiffPanel.class.st
+++ b/Iceberg-TipUI/IceTipDiffPanel.class.st
@@ -108,6 +108,18 @@ IceTipDiffPanel >> expandPath: aPath [
 		selectPath: aPath
 ]
 
+{ #category : #'event handling' }
+IceTipDiffPanel >> handleArrowLeft [
+
+	self collapsePath: iceNodesTree selection selectedPath
+]
+
+{ #category : #'event handling' }
+IceTipDiffPanel >> handleArrowRight [
+
+	self expandPath: iceNodesTree selection selectedPath
+]
+
 { #category : #'accessing - ui' }
 IceTipDiffPanel >> iceNodesTree [
 
@@ -148,9 +160,9 @@ IceTipDiffPanel >> initializeTree [
 		children: [ :each | each children ];
 		whenSelectionChangedDo: [ self selectionChanged ];
 		bindKeyCombination: Character arrowLeft asKeyCombination 
-			toAction: [ self collapsePath: iceNodesTree selection selectedPath ];
+			toAction: [ self handleArrowLeft ];
 		bindKeyCombination: Character arrowRight asKeyCombination 
-			toAction: [ self expandPath: iceNodesTree selection selectedPath ].
+			toAction: [ self handleArrowRight ].
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipTreeCollapseCommand.class.st
+++ b/Iceberg-TipUI/IceTipTreeCollapseCommand.class.st
@@ -32,9 +32,3 @@ IceTipTreeCollapseCommand >> execute [
 
 	self context doCollapseSelection
 ]
-
-{ #category : #accessing }
-IceTipTreeCollapseCommand >> shortcutKey [
-
-	^ Character arrowLeft asKeyCombination
-]

--- a/Iceberg-TipUI/IceTipTreeExpandCommand.class.st
+++ b/Iceberg-TipUI/IceTipTreeExpandCommand.class.st
@@ -37,9 +37,3 @@ IceTipTreeExpandCommand >> iconName [
 
 	^ nil
 ]
-
-{ #category : #accessing }
-IceTipTreeExpandCommand >> shortcutKey [
-
-	^ Character arrowRight asKeyCombination
-]


### PR DESCRIPTION
Commands should not have a shortcut for the arrows.
Shortcuts in commands are general to the window an they do not respect the focus of the selected widget.
Arrows should be handled with bindings to the presenter.
Those bindings respect the focus.