### PR TITLE
1468-IceProxyMCVersionInfogtDisplayString-should-be-removed

### DIFF
--- a/Iceberg/IceProxyMCVersionInfo.class.st
+++ b/Iceberg/IceProxyMCVersionInfo.class.st
@@ -14,7 +14,7 @@ Class {
 	#classVars : [
 		'LastCommitFound'
 	],
-	#category : 'Iceberg-Adapters'
+	#category : #'Iceberg-Adapters'
 }
 
 { #category : #private }
@@ -118,24 +118,6 @@ Please fetch from "{1}" and try again.'
 	^ IceMCVersionInfo new 
 		fromCommit: commit 
 		package: (IcePackage named: packageName repository: repo)
-]
-
-{ #category : #printing }
-IceProxyMCVersionInfo >> gtDisplayOn: stream [
-	"This offers a means to customize how the object is shown in the inspector"
-	^ self printOn: stream
-]
-
-{ #category : #printing }
-IceProxyMCVersionInfo >> gtDisplayString [
-	"This offers a means to customize how the object is shown in the inspector.
-	Do not override this method. Override gtDisplayOn: instead"
-		
-	| limitedString limit |
-	limit := 1000.
-	limitedString := String streamContents: [:s | self gtDisplayOn: s] limitedTo: limit.
-	limitedString size < limit ifTrue: [^ limitedString].
-	^ limitedString , ' ...'
 ]
 
 { #category : #inspecting }


### PR DESCRIPTION
Removing unused methods
Fix #1468 