### PR TITLE
Class side `#reset` method moved to `class initialization` protocol

### DIFF
--- a/Iceberg/IceRepository.class.st
+++ b/Iceberg/IceRepository.class.st
@@ -185,7 +185,7 @@ IceRepository class >> repositories [
 	^ self registry
 ]
 
-{ #category : #registry }
+{ #category : #'class initialization' }
 IceRepository class >> reset [
 	Registry := nil.
 	Iceberg announcer announce: IceRepositoryForgotten new.


### PR DESCRIPTION
Hi! 👋 this is a fix for #1534, which relates to https://github.com/pharo-project/pharo/issues/2607 in the language repo.