### PR TITLE
CI: use Pharo 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,14 @@ jobs:
       # Default value means that a failure in one OS cancels all 
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-9.0 ]
+        smalltalk: [ Pharo64-9.0, Pharo64-10 ]
         os: [ ubuntu-latest, macos-latest ]
         ston: [ .smalltalk.ston ]
         # Test Windows with some exclusions. 
         # At least a part of the problem is reported here: 
         # https://github.com/pharo-vcs/iceberg/issues/1394
         include:
-          - smalltalk: Pharo64-9.0
+          - smalltalk: Pharo64-10
             os: windows-latest
             ston: .smalltalk.windows.ston
     runs-on: ${{ matrix.os }}

--- a/scripts/testUpdateIceberg.sh
+++ b/scripts/testUpdateIceberg.sh
@@ -20,7 +20,7 @@ esac
 
 REPO_DIR="$(dirname "$SCRIPTS_DIR")"
 
-wget -O - get.pharo.org/64/90+vm | bash
+wget -O - get.pharo.org/64/100+vm | bash
 ./pharo Pharo.image st --save --quit "$SCRIPTS_DIR/preLoading.st"
 ./pharo Pharo.image metacello install "tonel://$REPO_DIR" BaselineOfIceberg --groups=$BASELINE_GROUPS
 ./pharo Pharo.image st --save --quit "$SCRIPTS_DIR/postLoading.st"


### PR DESCRIPTION
I suppose it's good to move. I kept P9 in ubuntu+macos... it should be enough. For windows, there is a special consideration in the yml file so P9 is excluded.