### PR TITLE
540-IceRepositorybranchesForMerge-should-be-deprecated-or-removed

### DIFF
--- a/Iceberg/IceRepository.class.st
+++ b/Iceberg/IceRepository.class.st
@@ -284,13 +284,6 @@ IceRepository >> branchNamed: aName ifPresent: presentBlock ifAbsent: absentBloc
 	self subclassResponsibility
 ]
 
-{ #category : #deprecated }
-IceRepository >> branchesForMerge: aCommit [
-	"Returns a list of local branches to which we could merge the received commit"
-
-	^ self allBranches reject: [ :each | each includesCommit: aCommit ]
-]
-
 { #category : #testing }
 IceRepository >> canPush [
 	


### PR DESCRIPTION
remove deprecated unused method #branchesForMerge:

fixes #1540

