### PR TITLE
Changing commit text presenter size

### DIFF
--- a/Iceberg-TipUI/IceTipCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCommitBrowser.class.st
@@ -43,6 +43,7 @@ IceTipCommitBrowser class >> defaultLayout [
 	^ SpPanedLayout newTopToBottom
 		  add: #diffPanel;
 		  add: #commentPanel;
+		  positionOfSlider: 75 percent;
 		  yourself
 ]
 


### PR DESCRIPTION
 Changed 'the commit message presenter size' in IceTipCommitBrowser class.

Before:
<img width="802" alt="Capture d’écran 2022-02-17 à 16 56 10" src="https://user-images.githubusercontent.com/33934979/154520148-4351bde3-0f17-404c-96f9-3f22e94d5790.png">

After:
<img width="803" alt="Capture d’écran 2022-02-17 à 16 56 23" src="https://user-images.githubusercontent.com/33934979/154520188-bc85a17f-4c4d-47f2-af0c-e7ac18bce4fe.png">


