### PR TITLE
Move the class side presence check to the patcher object

### DIFF
--- a/Iceberg/IceClassDefinition.class.st
+++ b/Iceberg/IceClassDefinition.class.st
@@ -84,27 +84,16 @@ IceClassDefinition >> isClassDefinition [
 ]
 
 { #category : #patching }
-IceClassDefinition >> removeFromPatcher: aMCPatcher [ 
-	
+IceClassDefinition >> removeFromPatcher: aMCPatcher [
+
 	"If the meta side is removed, we should modify the class definition to not include the meta-parts such as class-instance-variables"
+
 	self asMCDefinition ifNil: [ ^ self ].
-	
+
 	isMeta ifTrue: [ 
-		
-	"The patcher is storing the definitions by name of the class only.
-	We need to check it also if the original definition is the one we have here.
-	If it is, we can replace it in the patch.
-	But if it is not, we should not replace. If we replace it we will overwrite
-	the changes already in the patcher"
-		aMCPatcher definitions definitionLike: self asMCDefinition 
-			ifPresent: [ :found |
-				found = self asMCDefinition 
-				ifTrue: [
-					aMCPatcher
-						modifyDefinition: self asMCDefinition
-						to: self asMCDefinitionWithoutMetaSide]] 
-			ifAbsent: [].
-		^ self ].
-	
-	aMCPatcher removeDefinition: self asMCDefinition 
+		^ aMCPatcher
+			  modifyDefinition: self asMCDefinition
+			  to: self asMCDefinitionWithoutMetaSide ].
+
+	aMCPatcher removeDefinition: self asMCDefinition
 ]


### PR DESCRIPTION
https://github.com/pharo-project/pharo/issues/10623

The patcher can be a loader tracking changes or a patcher tracking a snapshot, so asking for definitions is not correct on the first one.

Integrate after https://github.com/pharo-project/pharo/pull/10950