### PR TITLE
Fix Pharo's #11370: Cannot commit when adding a class instance variable

### DIFF
--- a/Iceberg-Tests/IceClassesCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceClassesCherryPickingTest.class.st
@@ -39,7 +39,7 @@ IceClassesCherryPickingTest >> testAddClassDependingInATrait [
 
 	self assert: diff children size equals: 1.
 	
-	self assert: (diff / self packageName1) children size equals: 2.
+	self assert: (diff / self packageName1) children size equals: 3.
 	self
 		assert: (diff / self packageName1 / 'TestClass2') value isAddition.
 	self
@@ -87,7 +87,7 @@ IceClassesCherryPickingTest >> testAddClassDependingInATraitWithComposition [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 2.
+	self assert: (diff / self packageName1) children size equals: 3.
 
 	self
 		assert: (diff / self packageName1 / 'TestClass2') value isAddition.
@@ -126,7 +126,7 @@ IceClassesCherryPickingTest >> testAddClassSideMethodInExistingClass [
 	self
 		assert:
 			(diff / self packageName1 / 'TestClass class')
-				value isAddition.
+				value isNoModification.
 
 	self
 		assert:
@@ -163,7 +163,7 @@ IceClassesCherryPickingTest >> testAddClassUsingASharedPool [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 4.
 
 	self
 		assert:
@@ -204,7 +204,7 @@ IceClassesCherryPickingTest >> testAddClassWithMethod [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 1.
+	self assert: (diff / self packageName1) children size equals: 2.
 	self
 		assert: (diff / self packageName1 / 'TestClass2') value isAddition;
 		assert:
@@ -244,7 +244,7 @@ IceClassesCherryPickingTest >> testAddClassWithSuperclassAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 4.
 	self
 		should: [ diff / self packageName1 / 'C' ]
 		raise: NotFound.
@@ -281,7 +281,7 @@ IceClassesCherryPickingTest >> testAddClassWithoutDependencies [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff  / self packageName1) children size
-		equals: 1.
+		equals: 2.
 	self
 		assert:
 			(diff / self packageName1 / 'TestClass2') value
@@ -352,7 +352,7 @@ IceClassesCherryPickingTest >> testRemoveClassWithSubclasses [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 2.
+	self assert: (diff / self packageName1) children size equals: 4.
 	self
 		assert: (diff / self packageName1 / 'TestClass') value isRemoval.
 	self
@@ -400,7 +400,7 @@ IceClassesCherryPickingTest >> testRemoveClassWithSubclassesAndIntermediarySubcl
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 2.
+	self assert: (diff / self packageName1) children size equals: 4.
 	self assert: (diff / self packageName1 / 'TestClass') value isRemoval.
 	self
 		assert: (diff / self packageName1 / 'TestSubclass') value isRemoval

--- a/Iceberg-Tests/IceExtensionMethodCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceExtensionMethodCherryPickingTest.class.st
@@ -168,7 +168,7 @@ IceExtensionMethodCherryPickingTest >> testAddTwoExtensionMethodsInNonExistingCl
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 2.
-	self assert: (diff / self packageName1) children size equals: 1.
+	self assert: (diff / self packageName1) children size equals: 2.
 	self
 		assert: (diff / self packageName1 / 'TestClass2') value isAddition;
 		assert: (diff / self packageName1 / 'TestClass2') children size

--- a/Iceberg-Tests/IceMetaClassCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceMetaClassCherryPickingTest.class.st
@@ -55,9 +55,7 @@ IceMetaClassCherryPickingTest >> testAddMethodInMetaSideOfExistingClass [
 	self assert: diff children size equals: 1.
 	self assert: (diff / self packageName1) children size equals: 1.
 
-	self
-		deny: (diff / self packageName1 / 'TestClass class') value isModification.
-	self assert: (diff / self packageName1 / 'TestClass class') value isAddition.
+	self assert: (diff / self packageName1 / 'TestClass class') value isNoModification.
 
 	self
 		assert: (diff / self packageName1 / 'TestClass class' / 'm1') value isAddition
@@ -208,10 +206,7 @@ IceMetaClassCherryPickingTest >> testRemoveMethodInMetaSideOfExistingClass [
 	self assert: diff children size equals: 1.
 	self assert: (diff / self packageName1) children size equals: 1.
 
-	self
-		deny: (diff / self packageName1 / 'TestClass class') value isModification.
-	self
-		assert: (diff / self packageName1 / 'TestClass class') value isRemoval.
+	self assert: (diff / self packageName1 / 'TestClass class') value isNoModification.
 
 	self
 		assert: (diff / self packageName1 / 'TestClass class' / 'm1') value isRemoval.

--- a/Iceberg-Tests/IceMethodCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceMethodCherryPickingTest.class.st
@@ -30,7 +30,7 @@ IceMethodCherryPickingTest >> testAddMethodInClassAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 1.
+		equals: 2.
 
 	self
 		assert:
@@ -270,7 +270,7 @@ IceMethodCherryPickingTest >> testAddMethodUsingASharedPoolAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 4.
 
 	self
 		assert:
@@ -396,7 +396,7 @@ IceMethodCherryPickingTest >> testAddMethodWithClassAndSuperclassAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 4.
 
 	self
 		assert:
@@ -465,7 +465,7 @@ IceMethodCherryPickingTest >> testAddMethodWithClassVariableAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 4.
 
 	self
 		assert:
@@ -535,7 +535,7 @@ IceMethodCherryPickingTest >> testAddMethodWithClassVariableAsDependencyWithSupe
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 3.
 
 	self
 		assert:
@@ -594,7 +594,7 @@ IceMethodCherryPickingTest >> testAddMethodWithInstanceVariableAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 4.
 
 	self
 		assert:
@@ -659,7 +659,7 @@ IceMethodCherryPickingTest >> testAddMethodWithInstanceVariableAsDependencyWithS
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 3.
 
 	self
 		assert:
@@ -706,7 +706,7 @@ IceMethodCherryPickingTest >> testAddMethodWithReferencedClassAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 3.
 
 	self
 		assert:
@@ -824,7 +824,7 @@ IceMethodCherryPickingTest >> testRemoveClassWithMethods [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 1.
+	self assert: (diff / self packageName1) children size equals: 2.
 
 	self
 		assert: (diff / self packageName1 / 'TestClass2') value isRemoval.

--- a/Iceberg-Tests/IceMultiplePackageRepositoryTest.class.st
+++ b/Iceberg-Tests/IceMultiplePackageRepositoryTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #IceMultiplePackageRepositoryTest,
 	#superclass : #IceBornRepositoryTest,
-	#category : 'Iceberg-Tests-Common'
+	#category : #'Iceberg-Tests-Common'
 }
 
 { #category : #testing }
@@ -324,7 +324,7 @@ IceMultiplePackageRepositoryTest >> testCreateClassInImageMakesChangesContainCla
 
 	diff := self repository workingCopyDiff.
 	self assert: diff tree children size equals: 1.
-	self assert: (diff tree / self packageName1) children size equals: 1.
+	self assert: (diff tree / self packageName1) children size equals: 2.
 	self assert: (diff tree / self packageName1 / 'IceGeneratedClassForTesting') value isAddition.
 	self assert: (diff tree / self packageName1 / 'IceGeneratedClassForTesting') value definition isClassDefinition.
 	self assert: (diff tree / self packageName1 / 'IceGeneratedClassForTesting') value definition name equals: #IceGeneratedClassForTesting.

--- a/Iceberg-Tests/IceSinglePackageLocalRepositoryTest.class.st
+++ b/Iceberg-Tests/IceSinglePackageLocalRepositoryTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #IceSinglePackageLocalRepositoryTest,
 	#superclass : #IceBornRepositoryTest,
-	#category : 'Iceberg-Tests-Common'
+	#category : #'Iceberg-Tests-Common'
 }
 
 { #category : #testing }
@@ -31,7 +31,7 @@ IceSinglePackageLocalRepositoryTest >> testAddClassInstanceVariableIsExportedInC
 	diff := self repository headCommit diffToParent.
 	self assert: diff codeSubdirectoryNode children size equals: 1.
 	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 1.
-	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isAddition.
+	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isModification.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition isClassDefinition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition name equals: #'IceGeneratedClassForTesting class'.
 ]
@@ -88,7 +88,7 @@ IceSinglePackageLocalRepositoryTest >> testChangeClassSideMakesChangesContainCla
 	diff := self repository workingCopyDiff.
 	self assert: diff codeSubdirectoryNode children size equals: 1.
 	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 1.
-	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isAddition.
+	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isModification.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition isClassDefinition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition name equals: #'IceGeneratedClassForTesting class'.
 ]
@@ -114,7 +114,7 @@ IceSinglePackageLocalRepositoryTest >> testChangeClassSideMakesIsExportedInCommi
 	diff := self repository headCommit diffToParent.
 	self assert: diff codeSubdirectoryNode children size equals: 1.
 	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 1.
-	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isAddition.
+	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isModification.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition isClassDefinition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition name equals: #'IceGeneratedClassForTesting class'.
 ]
@@ -277,7 +277,7 @@ IceSinglePackageLocalRepositoryTest >> testChangeClassWithTraitsSideMakesIsExpor
 	diff := self repository headCommit diffToParent.
 	self assert: diff codeSubdirectoryNode children size equals: 1.
 	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 1.
-	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isAddition.
+	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isModification.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition isClassDefinition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition name equals: #'IceGeneratedClassForTesting class'.
 ]
@@ -570,7 +570,7 @@ IceSinglePackageLocalRepositoryTest >> testCreateClassInImageMakesChangesContain
 
 	diff := self repository workingCopyDiff.
 	self assert: diff codeSubdirectoryNode children size equals: 1.
-	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 1 "Class and Metaclass".
+	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 2 "Class and Metaclass".
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting') value isAddition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting') value definition isClassDefinition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting') value definition name equals: #IceGeneratedClassForTesting.
@@ -717,7 +717,7 @@ IceSinglePackageLocalRepositoryTest >> testRemoveClassInstanceVariableIsExported
 	diff := self repository headCommit diffToParent.
 	self assert: diff codeSubdirectoryNode children size equals: 1.
 	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 1.
-	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isRemoval.
+	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isModification.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition isClassDefinition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value definition name equals: #'IceGeneratedClassForTesting class'.
 ]

--- a/Iceberg-Tests/IceTraitsCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceTraitsCherryPickingTest.class.st
@@ -95,7 +95,7 @@ IceTraitsCherryPickingTest >> testRemoveTraitUsedByAClass [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 2.
+	self assert: (diff / self packageName1) children size equals: 3.
 	self
 		assert: (diff / self packageName1 / 'TestTraitInitial') value isRemoval.
 	self

--- a/Iceberg-TipUI/IceTipCritiquesBeforeCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCritiquesBeforeCommitBrowser.class.st
@@ -90,7 +90,7 @@ IceTipCritiquesBeforeCommitBrowser >> doAutofix [
 
 	critiquesList selectedItem ifNotNil: [ :aCritique | 
 		(RePropertyAction new
-			 icon: (aCritique iconNamed: #repairIcon);
+			 icon: (aCritique iconNamed: #repair);
 			 description: 'Automatically resolve the issue';
 			 action: [ :crit | 
 				 | changesBrowser |

--- a/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
@@ -105,7 +105,7 @@ IceTipCommitBrowserTest >> testIsCommitingCheckedItems [
 
 	presenter doCommit.
 	diffTree := self workingCopy repository branch commit diffToParent	tree.
-	self assert: (diffTree / self packageName1) children size equals: 1.
+	self assert: (diffTree / self packageName1) children size equals: 2.
 	self assert: (diffTree / self packageName1) value isNoModification.
 	self
 		assert: (diffTree / self packageName1 / 'TestClass2') value isAddition.
@@ -152,7 +152,7 @@ IceTipCommitBrowserTest >> testIsNotCommitingUncheckedItems [
 	presenter doCommit.
 	diffTree := self workingCopy repository branch commit diffToParent
 		tree.
-	self assert: (diffTree / self packageName1) children size equals: 1.
+	self assert: (diffTree / self packageName1) children size equals: 2.
 	self assert: (diffTree / self packageName1) value isNoModification.
 	self
 		assert: (diffTree / self packageName1 / 'TestClass2') value isAddition.

--- a/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
@@ -15,6 +15,7 @@ IceTipCommitBrowserTest class >> isAbstract [
 
 { #category : #running }
 IceTipCommitBrowserTest >> setUp [
+
 	super setUp.
 	self repository workingCopy addPackageNamed: self packageName1.
 	self repository workingCopy
@@ -26,7 +27,7 @@ IceTipCommitBrowserTest >> setUp [
 	presenter := IceTipCommitBrowser onRepository: self repository.
 	saveMock := IceTipMockSaveImageAction new.
 	presenter saveAction: saveMock.
-	presenter openWithSpec.
+	presenter open.
 	presenter commentPanel commentText text: 'my super commit message'
 ]
 

--- a/Iceberg-UI-Tests/IceTipCommitBrowserTestWithRemoteSet.class.st
+++ b/Iceberg-UI-Tests/IceTipCommitBrowserTestWithRemoteSet.class.st
@@ -42,7 +42,7 @@ IceTipCommitBrowserTestWithRemoteSet >> testPushingAutomatically [
 	presenter doCommit.
 	diffTree := fixture pushRepository branch commit diffToParent
 		tree.
-	self assert: (diffTree / self packageName1) children size equals: 1.
+	self assert: (diffTree / self packageName1) children size equals: 2.
 	self assert: (diffTree / self packageName1) value isNoModification.
 	self
 		assert: (diffTree / self packageName1 / 'TestClass2') value isAddition.

--- a/Iceberg-UI-Tests/IceTipHistoryBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipHistoryBrowserTest.class.st
@@ -14,14 +14,15 @@ IceTipHistoryBrowserTest >> newFixture [
 
 { #category : #running }
 IceTipHistoryBrowserTest >> setUp [
+
 	| model iceTipPullModel |
 	super setUp.
 	model := IceTipRepositoryModel on: self repository.
 	iceTipPullModel := IceTipPullModel
-		repositoryModel: model
-		on: model entity.
+		                   repositoryModel: model
+		                   on: model entity.
 	presenter := IceTipHistoryBrowser on: iceTipPullModel.
-	presenter openWithSpec
+	presenter open
 ]
 
 { #category : #running }

--- a/Iceberg-UI-Tests/IceTipRepositoriesBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipRepositoriesBrowserTest.class.st
@@ -23,18 +23,23 @@ IceTipRepositoriesBrowserTest >> newRepositoryNamed: aName [
 
 { #category : #testing }
 IceTipRepositoriesBrowserTest >> setUp [
+
 	| alphabeticallyLastRepository |
 	super setUp.
-	
-	alphabeticallyFirstRepository := self newRepositoryNamed: 'anotherOne'.
+
+	alphabeticallyFirstRepository := self newRepositoryNamed:
+		                                 'anotherOne'.
 	alphabeticallyLastRepository := self newRepositoryNamed: 'zzzz last'.
-	
-	repositoryProvider := IceTipCollectionRepositoryProvider new collection: {
-		self repository. 
-		alphabeticallyLastRepository . 
-		alphabeticallyFirstRepository } asOrderedCollection.
-	presenter := IceTipRepositoriesBrowser newOnRepositoryProvider: repositoryProvider.
-	presenter openWithSpec.
+
+	repositoryProvider := IceTipCollectionRepositoryProvider new 
+		                      collection: { 
+				                      self repository.
+				                      alphabeticallyLastRepository.
+				                      alphabeticallyFirstRepository }
+				                      asOrderedCollection.
+	presenter := IceTipRepositoriesBrowser newOnRepositoryProvider:
+		             repositoryProvider.
+	presenter open
 ]
 
 { #category : #testing }

--- a/Iceberg-UI-Tests/IceTipRepositoryBrowserWithRemoteTest.class.st
+++ b/Iceberg-UI-Tests/IceTipRepositoryBrowserWithRemoteTest.class.st
@@ -11,9 +11,10 @@ IceTipRepositoryBrowserWithRemoteTest >> newFixture [
 
 { #category : #testing }
 IceTipRepositoryBrowserWithRemoteTest >> setUp [
+
 	super setUp.
 	presenter := IceTipRepositoryBrowser onRepository: self repository.
-	presenter openWithSpec.
+	presenter open
 ]
 
 { #category : #testing }

--- a/Iceberg-UI-Tests/IceTipRepositoryBrowserWithoutRemoteTest.class.st
+++ b/Iceberg-UI-Tests/IceTipRepositoryBrowserWithoutRemoteTest.class.st
@@ -12,10 +12,10 @@ IceTipRepositoryBrowserWithoutRemoteTest >> newFixture [
 
 { #category : #testing }
 IceTipRepositoryBrowserWithoutRemoteTest >> setUp [
+
 	super setUp.
-	presenter := IceTipRepositoryBrowser
-		onRepository: self repository.
-	presenter openWithSpec
+	presenter := IceTipRepositoryBrowser onRepository: self repository.
+	presenter open
 ]
 
 { #category : #testing }

--- a/Iceberg-UI-Tests/IceTipWorkingCopyBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipWorkingCopyBrowserTest.class.st
@@ -22,10 +22,11 @@ IceTipWorkingCopyBrowserTest >> contextMenuForIndex: index [
 
 { #category : #running }
 IceTipWorkingCopyBrowserTest >> setUp [
+
 	super setUp.
-	
+
 	presenter := IceTipWorkingCopyBrowser onRepository: self repository.
-	presenter openWithSpec.
+	presenter open
 ]
 
 { #category : #running }

--- a/Iceberg/IceClassDefinition.class.st
+++ b/Iceberg/IceClassDefinition.class.st
@@ -65,11 +65,6 @@ IceClassDefinition >> asMCDefinitionWithoutMetaSide [
 ]
 
 { #category : #accessing }
-IceClassDefinition >> basicName [
-	^ name
-]
-
-{ #category : #accessing }
 IceClassDefinition >> contents [
 	mcDefinition ifNil: [ ^ '' ].
 	^ self isMeta

--- a/Iceberg/IceCredentialStore.class.st
+++ b/Iceberg/IceCredentialStore.class.st
@@ -102,19 +102,25 @@ IceCredentialStore >> loadFromStore [
 
 	| array |
 	self flag: #pharoTodo. "implement an encrypted version"
-	
+
 	"If I don't have a store file I do nothing"
 	storeFile ifNil: [ ^ self ].
-	
+
 	"If the file is new, I cannot load it."
 	storeFile exists ifFalse: [ ^ self ].
-	
-	array := [
-		FLMaterializer new
-			filePath: storeFile resolve pathString;
-			materializeRoot ]
-				on: FLMaterializationError
-				do: [ ^ self ].
+
+	"Fuel API is not compatible between Pharo10 and Pharo11"
+	SystemVersion current major >= 11
+		ifTrue: [ 
+			array := [ 
+			         FLMaterializer new
+				         filePath: storeFile resolve pathString;
+				         materializeRoot ]
+				         on: FLMaterializationError
+				         do: [ ^ self ] ]
+		ifFalse: [ 
+			array := FLMaterializer materializeFromFileNamed:
+				         storeFile resolve pathString ].
 	plainCredentials := array at: 1.
 	sshCredentials := array at: 2
 ]

--- a/Iceberg/IceCredentialStore.class.st
+++ b/Iceberg/IceCredentialStore.class.st
@@ -153,16 +153,28 @@ IceCredentialStore >> removeSSHCredential: aCredential [
 
 { #category : #'API - storing' }
 IceCredentialStore >> saveIntoStore [
+
 	self flag: #pharoTodo. "implement an encrypted version"
-		
-	storeFile ifNotNil: [  	
-		storeFile parent ensureCreateDirectory.	
-		
-		storeFile resolve binaryWriteStreamDo: [ :stream | 
-			FLSerializer new
-				onStream:  stream;
-				object: {plainCredentials. sshCredentials};
-				serialize ] ]
+
+	storeFile ifNil: [ ^ self ].
+	storeFile parent ensureCreateDirectory.
+
+	storeFile resolve binaryWriteStreamDo: [ :stream | 
+		"Fuel API changed in Pharo 11"
+		SystemVersion current major >= 11
+			ifTrue: [ 
+				FLSerializer new
+					onStream: stream;
+					object: { 
+							plainCredentials.
+							sshCredentials };
+					serialize ]
+			ifFalse: [ 
+				| serializer |
+				serializer := FLSerializer on: stream.
+				serializer serialize: { 
+						plainCredentials.
+						sshCredentials } ] ]
 ]
 
 { #category : #'API - accessing' }

--- a/Iceberg/IceDefinition.class.st
+++ b/Iceberg/IceDefinition.class.st
@@ -43,6 +43,12 @@ IceDefinition >> accept: aVisitor [
 ]
 
 { #category : #accessing }
+IceDefinition >> basicName [
+
+	^ name
+]
+
+{ #category : #accessing }
 IceDefinition >> contents [
 	
 	self subclassResponsibility

--- a/Iceberg/IceMCDefinitionImporter.class.st
+++ b/Iceberg/IceMCDefinitionImporter.class.st
@@ -51,25 +51,27 @@ IceMCDefinitionImporter >> snapshot: aMCSnapshot [
 ]
 
 { #category : #visiting }
-IceMCDefinitionImporter >> visitClassDefinition: aMCClassDefinition [ 
-	
+IceMCDefinitionImporter >> visitClassDefinition: aMCClassDefinition [
+
 	| classDefinitionNode classDefinition |
 	classDefinitionNode := self
-		ensureMethodOwnerNamed: aMCClassDefinition className
-		isMeta: false
-		isTrait: false
-		isExtension: false.
+		                       ensureMethodOwnerNamed:
+		                       aMCClassDefinition className
+		                       isMeta: false
+		                       isTrait: false
+		                       isExtension: false.
 	classDefinitionNode value mcDefinition: aMCClassDefinition.
-	
-	(aMCClassDefinition hasClassInstanceVariables
-		or: [aMCClassDefinition hasClassTraitComposition]) ifTrue: [
-		"We also generate the definition for the metaclass (See visitMetaclassDefinition: comment)"
-		classDefinition := self
-			ensureMethodOwnerNamed: aMCClassDefinition className
-			isMeta: true
-			isTrait: false
-			isExtension: false.
-		classDefinition value mcDefinition: aMCClassDefinition ].
+
+	"We also generate the definition for the metaclass (See visitMetaclassDefinition: comment).
+	We need both the instance and class side class nodes so they can contain their corresponding methods (that are visited in a random order)
+	=> Generate the class side definition always. If it turns out to be empty, we will filter it later."
+	classDefinition := self
+		                   ensureMethodOwnerNamed:
+		                   aMCClassDefinition className
+		                   isMeta: true
+		                   isTrait: false
+		                   isExtension: false.
+	classDefinition value mcDefinition: aMCClassDefinition.
 	^ classDefinitionNode
 ]
 


### PR DESCRIPTION
We also generate the definition for the metaclass (See visitMetaclass…Definition: comment).

We need both the instance and class side class nodes so they can contain their corresponding methods (that are visited in a random order)
	=> Generate the class side definition always. If it turns out to be empty, it is filtered out later
Fix https://github.com/pharo-project/pharo/issues/11370