### PR TITLE
Updating Libgit2 Bindings to version 2.2.6

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -76,7 +76,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v2.2.5';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v2.2.6';
   				loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'


### PR DESCRIPTION
To be compatible with Libgit2 1.4.4