### PR TITLE
Treat trait class side definitions like class class side definitions too

### DIFF
--- a/Iceberg-Tests/IceClassesCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceClassesCherryPickingTest.class.st
@@ -39,7 +39,7 @@ IceClassesCherryPickingTest >> testAddClassDependingInATrait [
 
 	self assert: diff children size equals: 1.
 	
-	self assert: (diff / self packageName1) children size equals: 3.
+	self assert: (diff / self packageName1) children size equals: 4.
 	self
 		assert: (diff / self packageName1 / 'TestClass2') value isAddition.
 	self
@@ -87,7 +87,7 @@ IceClassesCherryPickingTest >> testAddClassDependingInATraitWithComposition [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 3.
+	self assert: (diff / self packageName1) children size equals: 4.
 
 	self
 		assert: (diff / self packageName1 / 'TestClass2') value isAddition.

--- a/Iceberg-Tests/IceMethodCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceMethodCherryPickingTest.class.st
@@ -148,7 +148,7 @@ IceMethodCherryPickingTest >> testAddMethodInTraitAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 1.
+		equals: 2.
 
 	self
 		assert:
@@ -749,7 +749,7 @@ IceMethodCherryPickingTest >> testAddMethodWithReferencedTraitAsDependency [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 3.
 
 	self
 		assert:

--- a/Iceberg-Tests/IceSinglePackageLocalRepositoryTest.class.st
+++ b/Iceberg-Tests/IceSinglePackageLocalRepositoryTest.class.st
@@ -180,7 +180,7 @@ IceSinglePackageLocalRepositoryTest >> testChangeClassWithClassSideTraitsComposi
 
 	diff := self repository headCommit diffToParent.
 	self assert: diff codeSubdirectoryNode children size equals: 1.
-	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 3.
+	self assert: (diff codeSubdirectoryNode / self packageName1) children size equals: 4.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') value isAddition.
 	self assert: (diff codeSubdirectoryNode / self packageName1 / 'IceGeneratedClassForTesting class') 
 					value definition asMCDefinition hasClassTraitComposition.

--- a/Iceberg-Tests/IceTraitsCherryPickingTest.class.st
+++ b/Iceberg-Tests/IceTraitsCherryPickingTest.class.st
@@ -39,7 +39,7 @@ IceTraitsCherryPickingTest >> testAddTraitDependingInATrait [
 	self assert: diff children size equals: 1.
 	self
 		assert: (diff / self packageName1) children size
-		equals: 2.
+		equals: 4.
 
 	self
 		assert:
@@ -95,7 +95,7 @@ IceTraitsCherryPickingTest >> testRemoveTraitUsedByAClass [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 3.
+	self assert: (diff / self packageName1) children size equals: 4.
 	self
 		assert: (diff / self packageName1 / 'TestTraitInitial') value isRemoval.
 	self
@@ -135,7 +135,7 @@ IceTraitsCherryPickingTest >> testRemoveTraitUsedByATrait [
 	diff := mergeTree collect: [ :each | each chosenOperation ].
 
 	self assert: diff children size equals: 1.
-	self assert: (diff / self packageName1) children size equals: 2.
+	self assert: (diff / self packageName1) children size equals: 4.
 	self assert: (diff / self packageName1 / 'TestTraitInitial') value isRemoval.
 	self assert: (diff / self packageName1 / 'TestSubTrait') value isRemoval.
 ]

--- a/Iceberg/IceMCDefinitionImporter.class.st
+++ b/Iceberg/IceMCDefinitionImporter.class.st
@@ -129,14 +129,27 @@ IceMCDefinitionImporter >> visitOrganizationDefinition: aMCOrganizationDefinitio
 ]
 
 { #category : #visiting }
-IceMCDefinitionImporter >> visitTraitDefinition: aMCTraitDefinition [ 
-	
-	| traitDefinitionNode |
+IceMCDefinitionImporter >> visitTraitDefinition: aMCTraitDefinition [
+
+	| traitDefinitionNode classTraitDefinition |
 	traitDefinitionNode := self
-		ensureMethodOwnerNamed: aMCTraitDefinition className
-		isMeta: false
-		isTrait: true
-		isExtension: false.
+		                       ensureMethodOwnerNamed:
+		                       aMCTraitDefinition className
+		                       isMeta: false
+		                       isTrait: true
+		                       isExtension: false.
 	traitDefinitionNode value mcDefinition: aMCTraitDefinition.
+
+	"We also generate the definition for the class side trait.
+	We need both the instance and class side class nodes so they can contain their corresponding methods (that are visited in a random order)
+	=> Generate the trait side definition always. If it turns out to be empty, we will filter it later."
+	classTraitDefinition := self
+		                        ensureMethodOwnerNamed:
+		                        aMCTraitDefinition className
+		                        isMeta: true
+		                        isTrait: true
+		                        isExtension: false.
+	classTraitDefinition value mcDefinition: aMCTraitDefinition.
+
 	^ traitDefinitionNode
 ]

--- a/Iceberg/IceTraitDefinition.class.st
+++ b/Iceberg/IceTraitDefinition.class.st
@@ -25,13 +25,22 @@ IceTraitDefinition >> accept: aVisitor [
 ]
 
 { #category : #patching }
-IceTraitDefinition >> addModification: anIceModification toPatcher: aMCPatcher [ 
-	
+IceTraitDefinition >> addModification: anIceModification toPatcher: aMCPatcher [
+
+	"If the new definition has no class instance vaiables, we remove the meta side variables, and apply the new changes to the patcher "
+	(self isMeta and: [ mcDefinition isNil and: [ anIceModification rightDefinition asMCDefinition isNotNil ] ]) 
+		ifTrue: [ | defModification |
+			defModification := anIceModification rightDefinition asMCDefinition deepCopy.
+			defModification removeMetaSideVariables.
+			aMCPatcher
+				modifyDefinition: anIceModification rightDefinition asMCDefinition
+				to: defModification.
+			^ self ].
+
 	"We should not handle metaclasses if their mcDefinition is nil.
 	They should be added automatically when added the instance side."
-	(self isMeta and: [ mcDefinition isNil ])
-		ifTrue: [ ^ self ].
-	
+	(self isMeta and: [ mcDefinition isNil ]) ifTrue: [ ^ self ].
+
 	aMCPatcher
 		modifyDefinition: anIceModification rightDefinition asMCDefinition
 		to: anIceModification leftDefinition asMCDefinition


### PR DESCRIPTION
Fixes #1608 

Class side definitions should be created always, for traits as well as for classes.