### PR TITLE
Only compute critiques when needed

### DIFF
--- a/Iceberg-TipUI/IceTipCritiquesBeforeCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCritiquesBeforeCommitBrowser.class.st
@@ -245,7 +245,12 @@ IceTipCritiquesBeforeCommitBrowser >> titleForWindow [
 IceTipCritiquesBeforeCommitBrowser >> updatePresenter [ 
 
 	super updatePresenter.
-	critiques := (IceCritiquesVisitor new visitAll: self model; critiques) asOrderedCollection.
+	critiques := IceTipCommitSettings critiquesOnCommit
+		             ifFalse: [ OrderedCollection new ]
+		             ifTrue: [ 
+			             (IceCritiquesVisitor new
+				              visitAll: self model;
+				              critiques) asOrderedCollection ].
 	critiquesList items: critiques.
 
 	critiques ifNotEmpty: [ critiquesList selectIndex: 1].


### PR DESCRIPTION
There's a checkbox to prevent running critiques on commit, but its value was only used to enable/disable the critiques **display**, not its computation (IceTipCritiquesBeforeCommitBrowser>>#openIfCritiques)

I added logic in IceTipCritiquesBeforeCommitBrowser>>#updatePresenter to also enable/disable the computation