### PR TITLE
Fix/1426: ZnInvalidUTF8 when reading a commit message

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -76,7 +76,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v2.2.7';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v2.2.8';
   				loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'

--- a/Iceberg-Plugin-GitHub/IceTipGitHubRepositoryPanel.class.st
+++ b/Iceberg-Plugin-GitHub/IceTipGitHubRepositoryPanel.class.st
@@ -23,11 +23,17 @@ IceTipGitHubRepositoryPanel >> configureBuilder: aBuilder [
 { #category : #'querying - github' }
 IceTipGitHubRepositoryPanel >> getGitHubRepository [
 
-	^ [ IceGitHubAPI new
-		beAnonymous;
-		getRepository: self userName project: self projectName ]
-			on: LGitNoCredentialsProvided
-			do: [ nil ]
+	^ [ [ IceGitHubAPI new
+		  beAnonymous;
+		  getRepository: self userName project: self projectName ]
+		  on: LGitNoCredentialsProvided
+		  do: [ nil ] ]
+		  on: IceGitHubError
+		  do: [ :error | 
+			"If not found, probably means a private repository => ignore it"
+			error messageText = 'Not Found'
+				ifTrue: [ ^ nil ].
+			error pass ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Fix #1426
Fix #1184

- upgrade libgit for better encoding management of messages
- do not block repository creation if github API does not answer (not found, or missing credentials)