### PR TITLE
Make remote comparison work better between remotes with different urls

### DIFF
--- a/Iceberg-Libgit/IceGitHttpsRemote.class.st
+++ b/Iceberg-Libgit/IceGitHttpsRemote.class.st
@@ -22,9 +22,3 @@ IceGitHttpsRemote class >> protocolID [
 	
 	^'https'
 ]
-
-{ #category : #testing }
-IceGitHttpsRemote >> referencesSameRemoteLocationAs: aRemote [
-	^ (super referencesSameRemoteLocationAs: aRemote)
-		or: [ (self url withoutSuffix: '.git') sameAs: (aRemote httpsUrl withoutSuffix: '.git') ] 
-]

--- a/Iceberg-Libgit/IceGitNetworkRemote.class.st
+++ b/Iceberg-Libgit/IceGitNetworkRemote.class.st
@@ -106,7 +106,9 @@ IceGitNetworkRemote >> projectPath [
 
 { #category : #comparing }
 IceGitNetworkRemote >> referencesSameRemoteLocationAs: another [
-	^ (self url withoutSuffix: '.git') sameAs: (another url withoutSuffix: '.git')
+
+	^ (self httpsUrl withoutSuffix: '.git') sameAs:
+		  (another httpsUrl withoutSuffix: '.git')
 ]
 
 { #category : #private }

--- a/Iceberg-Libgit/IceGitScpRemote.class.st
+++ b/Iceberg-Libgit/IceGitScpRemote.class.st
@@ -75,10 +75,3 @@ IceGitScpRemote >> parseUrl [
 	restSegments isEmpty ifTrue: [ IceWrongUrl signal: 'Remote repository scheme not supported: ', url ].
 	projectName := self stripPossibleExtension: (restSegments last)
 ]
-
-{ #category : #testing }
-IceGitScpRemote >> referencesSameRemoteLocationAs: aRemote [
-	^ ((super referencesSameRemoteLocationAs: aRemote)
-		or: [ self httpsUrl = aRemote httpsUrl ])
-			
-]

--- a/Iceberg-Libgit/IceGitSshRemote.class.st
+++ b/Iceberg-Libgit/IceGitSshRemote.class.st
@@ -24,10 +24,3 @@ IceGitSshRemote >> httpsUrl [
 	^ 'https://{1}/{2}.git' format: { self host . self projectPath }
 
 ]
-
-{ #category : #testing }
-IceGitSshRemote >> referencesSameRemoteLocationAs: aRemote [
-	^ ((super referencesSameRemoteLocationAs: aRemote)
-		or: [ self httpsUrl sameAs: aRemote httpsUrl ])
-			
-]

--- a/Iceberg-Tests/IceGitRemoteTest.class.st
+++ b/Iceberg-Tests/IceGitRemoteTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #IceGitRemoteTest,
 	#superclass : #TestCase,
-	#category : 'Iceberg-Tests-Core-Remotes'
+	#category : #'Iceberg-Tests-Core-Remotes'
 }
 
 { #category : #'tests-scp' }
@@ -181,6 +181,22 @@ IceGitRemoteTest >> testGithubScpUrlShouldBeTransformableToHttps [
 	self assert: remote httpsUrl equals: 'https://github.com/npasserini/iceberg.git'
 ]
 
+{ #category : #'tests-ssh' }
+IceGitRemoteTest >> testHTTPSRemoteEqualsLocationThanSCPRemote [
+	| sshremote scpremote |
+	sshremote := IceGitHttpsRemote new url: 'https://github.com/pharo-vcs/iceberg.git'.
+	scpremote := IceGitScpRemote new url: 'git@github.com:pharo-vcs/iceberg.git'.
+	self assert: (sshremote referencesSameRemoteLocationAs: scpremote).
+]
+
+{ #category : #'tests-ssh' }
+IceGitRemoteTest >> testHTTPSRemoteNotEqualsLocationThanSCPRemote [
+	| sshremote scpremote |
+	sshremote := IceGitHttpsRemote new url: 'https://github.com/pharo-vcs/iceberg.git'.
+	scpremote := IceGitScpRemote new url: 'git@github.com:different/iceberg.git'.
+	self deny: (sshremote referencesSameRemoteLocationAs: scpremote).
+]
+
 { #category : #'tests-scp' }
 IceGitRemoteTest >> testNonGithubImplicitScpUrlExtractsFullUrlPath [
 	| url |
@@ -308,4 +324,20 @@ IceGitRemoteTest >> testNonGithubScpUrlShouldBeTransformableToHttps [
 	
 	url := IceGitScpRemote new url: 'ssh://git.fremont.lamrc.net/diffuse/300/rdebug.git'.
 	self assert: url httpsUrl equals: 'https://git.fremont.lamrc.net/diffuse/300/rdebug.git'
+]
+
+{ #category : #'tests-ssh' }
+IceGitRemoteTest >> testSSHRemoteEqualsLocationThanSCPRemote [
+	| sshremote scpremote |
+	sshremote := IceGitSshRemote new url: 'git://github.com/pharo-vcs/iceberg.git'.
+	scpremote := IceGitScpRemote new url: 'git@github.com:pharo-vcs/iceberg.git'.
+	self assert: (sshremote referencesSameRemoteLocationAs: scpremote).
+]
+
+{ #category : #'tests-ssh' }
+IceGitRemoteTest >> testSSHRemoteNotEqualsLocationThanSCPRemote [
+	| sshremote scpremote |
+	sshremote := IceGitSshRemote new url: 'git://github.com/pharo-vcs/iceberg.git'.
+	scpremote := IceGitScpRemote new url: 'git@github.com:different/iceberg.git'.
+	self deny: (sshremote referencesSameRemoteLocationAs: scpremote).
 ]


### PR DESCRIPTION
This allows comparing ssh and https remotes, being able to detect when a clone points to a repository regardless of its url schema.