### PR TITLE
Fix for adding a SSH credential from UI raises an Error

### DIFF
--- a/Iceberg-TipUI/IceTipEntityModel.class.st
+++ b/Iceberg-TipUI/IceTipEntityModel.class.st
@@ -99,6 +99,6 @@ IceTipEntityModel >> shortDescription [
 	"Answer a <String> describing a short version of the receiver from its description. If there is no description, answer an empty <String> to avoid breaking the Push (see https://github.com/pharo-project/pharo/issues/12123)"
 
 	^ self description asString
+		ifNotEmpty: [ :aString | aString lines first ]
 		ifEmpty: [ String empty ]
-		ifNotEmpty: [ : d | d lines first ]
 ]


### PR DESCRIPTION
Instead of nil, this modification defaults to the HOME FileReference in IceTipLocationPresenter>>location, avoiding an Error when a SSH credential is added from UI. This happens after clicking the browse Public or Private buttons to select the Public/Private keys.