### PR TITLE
Fix Crash when invalid credentials

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -76,7 +76,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.0.0';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.0.3';
   			loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'

--- a/Iceberg-TipUI/LGitCredentialsPlaintext.extension.st
+++ b/Iceberg-TipUI/LGitCredentialsPlaintext.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #LGitCredentialsPlaintext }
+
+{ #category : #'*Iceberg-TipUI' }
+LGitCredentialsPlaintext >> askForModelClassOn: aString [ 
+	
+	^ IceTipAskForPlaintextCredentialsModel
+]


### PR DESCRIPTION
Related to: https://github.com/pharo-project/pharo-vm/issues/513

When the credentials callback opens the dialog, if an error happens during the dialog opening, libgit crashes.
This PR:
 - updates libgit to v3.0.3 that does a better management of credentials callbacks
 - updates iceberg to not fail when opening the pop up