### PR TITLE
Fix for issue #11969 in pharo repository: Better description "packages unloaded packages

### DIFF
--- a/Iceberg-TipUI/IceTipAddNewPackagesDialog.class.st
+++ b/Iceberg-TipUI/IceTipAddNewPackagesDialog.class.st
@@ -15,6 +15,16 @@ Class {
 	#category : #'Iceberg-TipUI-View-Branch'
 }
 
+{ #category : #commands }
+IceTipAddNewPackagesDialog class >> buildCommandsGroupWith: presenterInstance forRoot: rootCommandGroup [
+
+	rootCommandGroup register:
+		((CmCommandGroup named: 'package list commands') asSpecGroup
+			 register: IceTipSelectAllPackagesCommand forSpec;
+			 register: IceTipUnselectAllPackagesCommand forSpec;
+			 yourself)
+]
+
 { #category : #actions }
 IceTipAddNewPackagesDialog >> accept [
 
@@ -30,16 +40,6 @@ IceTipAddNewPackagesDialog >> accept [
 			self closeWindow.
 			checkoutPreviewWindow closeWindow ];
 		executeWithContext: self
-]
-
-{ #category : #commands }
-IceTipAddNewPackagesDialog >> buildCommandsGroupWith: presenterInstance forRoot: rootCommandGroup [
-
-	rootCommandGroup
-		register: ((CmCommandGroup named: 'package list commands') asSpecGroup
-			register: IceTipSelectAllPackagesCommand forSpec;
-			register: IceTipUnselectAllPackagesCommand forSpec;
-			yourself)
 ]
 
 { #category : #accessing }
@@ -118,6 +118,18 @@ IceTipAddNewPackagesDialog >> packagesList [
 IceTipAddNewPackagesDialog >> selectedPackage [
 
 	^ packagesList selectedItem
+]
+
+{ #category : #accessing }
+IceTipAddNewPackagesDialog >> selectedPackages [
+
+	^ selectedPackages
+]
+
+{ #category : #accessing }
+IceTipAddNewPackagesDialog >> selectedPackages: anObject [
+
+	selectedPackages := anObject
 ]
 
 { #category : #'accessing - model' }

--- a/Iceberg-TipUI/IceTipAddNewPackagesDialog.class.st
+++ b/Iceberg-TipUI/IceTipAddNewPackagesDialog.class.st
@@ -32,6 +32,16 @@ IceTipAddNewPackagesDialog >> accept [
 		executeWithContext: self
 ]
 
+{ #category : #commands }
+IceTipAddNewPackagesDialog >> buildCommandsGroupWith: presenterInstance forRoot: rootCommandGroup [
+
+	rootCommandGroup
+		register: ((CmCommandGroup named: 'package list commands') asSpecGroup
+			register: IceTipSelectAllPackagesCommand forSpec;
+			register: IceTipUnselectAllPackagesCommand forSpec;
+			yourself)
+]
+
 { #category : #accessing }
 IceTipAddNewPackagesDialog >> checkoutModel: anIceTipCheckoutModel [ 
 	
@@ -62,21 +72,22 @@ IceTipAddNewPackagesDialog >> iconForWindow [
 { #category : #initialization }
 IceTipAddNewPackagesDialog >> initializePackagesList [
 
-	packagesList addColumn: (SpCompositeTableColumn new
-		addColumn: (SpCheckBoxTableColumn new
-			evaluated: [ :item | selectedPackages includes: item ];
-			onActivation: [ :item | selectedPackages add: item ];
-			onDeactivation: [ :item | selectedPackages remove: item ifAbsent: [  ] ];
-			beNotExpandable;
-			yourself);
-		addColumn: (SpImageTableColumn new
-			evaluated: [ :each | self iconNamed: #package ];
-			beNotExpandable;
-			yourself);
-		addColumn: (SpStringTableColumn new
-			evaluated: [:e | e name];
-			yourself);
-		yourself)
+	packagesList
+		addColumn: (SpCompositeTableColumn new
+			addColumn: (SpCheckBoxTableColumn new
+				evaluated: [ :item | selectedPackages includes: item ];
+				onActivation: [ :item | selectedPackages add: item ];
+				onDeactivation: [ :item | selectedPackages remove: item ifAbsent: [  ] ];
+				beNotExpandable;
+				yourself);
+			addColumn: (SpImageTableColumn new
+				evaluated: [ :each | self iconNamed: #package ];
+				beNotExpandable;
+				yourself);
+			addColumn: (SpStringTableColumn new
+				evaluated: [:e | e name];
+				yourself));
+		contextMenu: [ (self rootCommandsGroup / 'package list commands') beRoot asMenuPresenter ]
 ]
 
 { #category : #initialization }
@@ -122,8 +133,8 @@ IceTipAddNewPackagesDialog >> titleForWindow [
 ]
 
 { #category : #initialization }
-IceTipAddNewPackagesDialog >> updatePresenter [ 
-	
+IceTipAddNewPackagesDialog >> updatePresenter [
+
 	packagesList items: packages
 ]
 

--- a/Iceberg-TipUI/IceTipSelectAllPackagesCommand.class.st
+++ b/Iceberg-TipUI/IceTipSelectAllPackagesCommand.class.st
@@ -1,0 +1,50 @@
+"
+Implements the select all option behavior in the ""Select New Packages to Load"" Iceberg dialog.
+
+"
+Class {
+	#name : #IceTipSelectAllPackagesCommand,
+	#superclass : #IceTipSelectPackagesCommand,
+	#category : #'Iceberg-TipUI-Commands'
+}
+
+{ #category : #default }
+IceTipSelectAllPackagesCommand class >> defaultDescription [
+
+	^ 'Opens a dialog to choose select and/or removing new package(s) from the repository'
+]
+
+{ #category : #default }
+IceTipSelectAllPackagesCommand class >> defaultName [
+
+	^ 'Select all packages'
+]
+
+{ #category : #testing }
+IceTipSelectAllPackagesCommand >> canBeExecuted [
+	" Answer <true> if the receiver has items to display and they are not all selected "
+
+	| pkgList |
+
+	pkgList := self context packagesList.
+ 	^ pkgList items notEmpty and: [ pkgList items size ~= pkgList selectedItems size ]
+]
+
+{ #category : #executing }
+IceTipSelectAllPackagesCommand >> execute [
+	" Private - Select all the receiver's packages "
+
+	self packagesList items
+		do: [ : pkgItem |
+			self packagesListSelectionColumn
+				select: [ : c | c isKindOf: SpCheckBoxTableColumn ]
+				thenDo: [ : c | c onActivation cull: pkgItem ] ]
+		displayingProgress: [ : pkgItem | 'Selecting ' , pkgItem name ].
+	self packagesList refresh
+]
+
+{ #category : #accessing }
+IceTipSelectAllPackagesCommand >> iconName [
+
+	^ #checkboxSelected
+]

--- a/Iceberg-TipUI/IceTipSelectAllPackagesCommand.class.st
+++ b/Iceberg-TipUI/IceTipSelectAllPackagesCommand.class.st
@@ -26,7 +26,7 @@ IceTipSelectAllPackagesCommand >> canBeExecuted [
 
 	| pkgList |
 
-	pkgList := self context packagesList.
+	pkgList := self packagesList.
  	^ pkgList items notEmpty and: [ pkgList items size ~= pkgList selectedItems size ]
 ]
 
@@ -34,12 +34,7 @@ IceTipSelectAllPackagesCommand >> canBeExecuted [
 IceTipSelectAllPackagesCommand >> execute [
 	" Private - Select all the receiver's packages "
 
-	self packagesList items
-		do: [ : pkgItem |
-			self packagesListSelectionColumn
-				select: [ : c | c isKindOf: SpCheckBoxTableColumn ]
-				thenDo: [ : c | c onActivation cull: pkgItem ] ]
-		displayingProgress: [ : pkgItem | 'Selecting ' , pkgItem name ].
+	self context selectedPackages: self packagesList items.
 	self packagesList refresh
 ]
 

--- a/Iceberg-TipUI/IceTipSelectPackagesCommand.class.st
+++ b/Iceberg-TipUI/IceTipSelectPackagesCommand.class.st
@@ -1,0 +1,24 @@
+"
+Provides common behavior to accesing the packages list presenters in its context.
+"
+Class {
+	#name : #IceTipSelectPackagesCommand,
+	#superclass : #IceTipPackageCommand,
+	#category : #'Iceberg-TipUI-Commands'
+}
+
+{ #category : #executing }
+IceTipSelectPackagesCommand >> packagesList [
+	" Answer a <SpTablePresenter> including the receiver's packages "
+	
+	^ self context packagesList
+]
+
+{ #category : #executing }
+IceTipSelectPackagesCommand >> packagesListSelectionColumn [
+	" Answer a <SpCheckBoxTableColumn> to select packages in the receiver's context package list "
+
+	| compositeCol |
+	compositeCol := self packagesList columns.
+	^ compositeCol anyOne columns select: [ : c | c isKindOf: SpCheckBoxTableColumn ]
+]

--- a/Iceberg-TipUI/IceTipSelectPackagesCommand.class.st
+++ b/Iceberg-TipUI/IceTipSelectPackagesCommand.class.st
@@ -13,12 +13,3 @@ IceTipSelectPackagesCommand >> packagesList [
 	
 	^ self context packagesList
 ]
-
-{ #category : #executing }
-IceTipSelectPackagesCommand >> packagesListSelectionColumn [
-	" Answer a <SpCheckBoxTableColumn> to select packages in the receiver's context package list "
-
-	| compositeCol |
-	compositeCol := self packagesList columns.
-	^ compositeCol anyOne columns select: [ : c | c isKindOf: SpCheckBoxTableColumn ]
-]

--- a/Iceberg-TipUI/IceTipUnselectAllPackagesCommand.class.st
+++ b/Iceberg-TipUI/IceTipUnselectAllPackagesCommand.class.st
@@ -34,12 +34,7 @@ IceTipUnselectAllPackagesCommand >> canBeExecuted [
 IceTipUnselectAllPackagesCommand >> execute [
 	" Private - Unselect all the receiver's packages "
 
-	self packagesList items
-		do: [ : pkgItem |
-			self packagesListSelectionColumn
-				select: [ : c | c isKindOf: SpCheckBoxTableColumn ]
-				thenDo: [ : c | c onDeactivation cull: pkgItem ] ]
-		displayingProgress: [ : pkgItem | 'Unselecting ' , pkgItem name ].
+	self context selectedPackages: OrderedCollection empty.
 	self packagesList refresh
 ]
 

--- a/Iceberg-TipUI/IceTipUnselectAllPackagesCommand.class.st
+++ b/Iceberg-TipUI/IceTipUnselectAllPackagesCommand.class.st
@@ -1,0 +1,50 @@
+"
+Implements the unselect all option behavior in the ""Select New Packages to Load"" Iceberg dialog.
+
+"
+Class {
+	#name : #IceTipUnselectAllPackagesCommand,
+	#superclass : #IceTipSelectPackagesCommand,
+	#category : #'Iceberg-TipUI-Commands'
+}
+
+{ #category : #'accessing - defaults' }
+IceTipUnselectAllPackagesCommand class >> defaultDescription [
+
+	^ 'Opens a dialog to choose select and/or removing new package(s) from the repository'
+]
+
+{ #category : #default }
+IceTipUnselectAllPackagesCommand class >> defaultName [
+
+	^ 'Unselect all packages'
+]
+
+{ #category : #testing }
+IceTipUnselectAllPackagesCommand >> canBeExecuted [
+	" Answer <true> if the receiver has items to display "
+
+	| pkgList |
+
+	pkgList := self context packagesList.
+ 	^ pkgList items notEmpty
+]
+
+{ #category : #executing }
+IceTipUnselectAllPackagesCommand >> execute [
+	" Private - Unselect all the receiver's packages "
+
+	self packagesList items
+		do: [ : pkgItem |
+			self packagesListSelectionColumn
+				select: [ : c | c isKindOf: SpCheckBoxTableColumn ]
+				thenDo: [ : c | c onDeactivation cull: pkgItem ] ]
+		displayingProgress: [ : pkgItem | 'Unselecting ' , pkgItem name ].
+	self packagesList refresh
+]
+
+{ #category : #accessing }
+IceTipUnselectAllPackagesCommand >> iconName [
+
+	^ #checkboxUnselected
+]


### PR DESCRIPTION
Add a context group menu for the dialog in IceTipAddNewPackagesDialog. Implements two options: Select All and Unselect All packages.
These are implemented in two IceTipSelectPackagesCommand subclasses.

Reported in: https://github.com/pharo-project/pharo/issues/11969
