### PR TITLE
1686-SSH-Key-pair-should-not-ask-user-it-should-use-the-user-from-the-URL

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -72,13 +72,13 @@ BaselineOfIceberg >> customProjectAttributes [
 
 { #category : #baseline }
 BaselineOfIceberg >> libgit: spec [
-	spec 
-		baseline: 'LibGit' 
-		with: [ 
+	spec
+		baseline: 'LibGit'
+		with: [
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.0.4';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.0.5';
   			loads: 'default' ].
-	spec  
+	spec
 		project: 'LibGit-Tests'
 		copyFrom: 'LibGit'
 		with: [ spec loads: #('tests') ]

--- a/Iceberg-TipUI/IceTipAbstractCredentialsModel.class.st
+++ b/Iceberg-TipUI/IceTipAbstractCredentialsModel.class.st
@@ -71,8 +71,7 @@ IceTipAbstractCredentialsModel >> cancelAction [
 IceTipAbstractCredentialsModel >> cancelAskAction [
 
 	accepted := true.
-	self closeWindow.
-	LGitNoCredentialsProvided signal
+	self closeWindow
 ]
 
 { #category : #actions }
@@ -159,12 +158,12 @@ IceTipAbstractCredentialsModel >> open [
 	^ self credentials
 ]
 
-{ #category : #accessing }
+{ #category : #actions }
 IceTipAbstractCredentialsModel >> refreshCredentialsFromPresenter [
 	"Hook to update the credentials object from the presenter inputs."
 ]
 
-{ #category : #accessing }
+{ #category : #actions }
 IceTipAbstractCredentialsModel >> refreshPresenterFromCredentials [
 	"Hook to update the presenter input fields from the credentials object."
 ]

--- a/Iceberg-TipUI/IceTipAbstractSSHCredentialsModel.class.st
+++ b/Iceberg-TipUI/IceTipAbstractSSHCredentialsModel.class.st
@@ -6,8 +6,6 @@ Class {
 	#name : #IceTipAbstractSSHCredentialsModel,
 	#superclass : #IceTipAbstractCredentialsModel,
 	#instVars : [
-		'usernameInput',
-		'usernameLabel',
 		'publicKeyInput',
 		'privateKeyInput',
 		'passphraseInput',
@@ -22,13 +20,6 @@ Class {
 IceTipAbstractSSHCredentialsModel >> initializePresenters [
 
 	super initializePresenters.
-	usernameLabel := self newLabel
-		label: 'Username: ';
-		yourself.
-	usernameInput := self newTextInput
-		autoAccept: true;
-		whenTextChangedDo: [ self updateOkButton ];
-		yourself.
 	passphraseLabel := self newLabel
 		label: 'Key Passphrase: ';
 		yourself.
@@ -52,15 +43,13 @@ IceTipAbstractSSHCredentialsModel >> initializePresenters [
 		onChoose: [ self updateOkButton ];
 		chooseTitle: 'Select Public Key';
 		whenTextChanged: [ self updateOkButton ];
-		yourself.
-
+		yourself
 ]
 
 { #category : #testing }
 IceTipAbstractSSHCredentialsModel >> isOkEnabled [
 
-	^ self username isNotEmpty and: [ 
-		  self publicKey isNotEmpty and: [ self privateKey isNotEmpty ] ]
+	^ self publicKey isNotEmpty and: [ self privateKey isNotEmpty ]
 ]
 
 { #category : #accessing }
@@ -83,10 +72,4 @@ IceTipAbstractSSHCredentialsModel >> publicKey [
 	^ publicKeyInput location
 		  ifNil: [ '' ]
 		  ifNotNil: [ :x | x pathString ]
-]
-
-{ #category : #accessing }
-IceTipAbstractSSHCredentialsModel >> username [
-
-	^ usernameInput text
 ]

--- a/Iceberg-TipUI/IceTipAddSSHCredentialsModel.class.st
+++ b/Iceberg-TipUI/IceTipAddSSHCredentialsModel.class.st
@@ -25,7 +25,6 @@ IceTipAddSSHCredentialsModel >> defaultLayout [
 		column: 2 expand: true;
 		build: [ :builder | builder
 			add: hostLabel; add: hostInput; nextRow;
-			add: usernameLabel; add: usernameInput; nextRow;
 			add: publicKeyLabel; add: publicKeyInput; nextRow;
 			add: privateKeyLabel; add: privateKeyInput; nextRow;
 			add: passphraseLabel; add: passphraseInput; nextRow ]
@@ -59,13 +58,12 @@ IceTipAddSSHCredentialsModel >> initializePresenters [
 
 { #category : #accessing }
 IceTipAddSSHCredentialsModel >> newCredentials [
-	
+
 	^ IceSshCredentials new
-		username: self username;
 		publicKey: self publicKey;
 		privateKey: self privateKey;
 		keyPassphrase: self passphrase;
-		yourself 
+		yourself
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipAskSSHCredentialsModel.class.st
+++ b/Iceberg-TipUI/IceTipAskSSHCredentialsModel.class.st
@@ -19,6 +19,13 @@ IceTipAskSSHCredentialsModel >> cancelAction [
 	self cancelAskAction
 ]
 
+{ #category : #actions }
+IceTipAskSSHCredentialsModel >> cancelAskAction [
+
+	super cancelAskAction.
+	LGitNoCredentialsProvided signal
+]
+
 { #category : #accessing }
 IceTipAskSSHCredentialsModel >> newCredentials [
 

--- a/Iceberg-TipUI/IceTipEditSSHCredentialsModel.class.st
+++ b/Iceberg-TipUI/IceTipEditSSHCredentialsModel.class.st
@@ -16,12 +16,11 @@ IceTipEditSSHCredentialsModel >> accept [
 { #category : #layout }
 IceTipEditSSHCredentialsModel >> defaultLayout [
 
-	^ SpGridLayout new 
+	^ SpGridLayout new
 		beColumnNotHomogeneous;
 		column: 2 expand: true;
-		build: [ :builder | builder 
-			add: usernameLabel; add: usernameInput; nextRow; 
-			add: publicKeyLabel; add: publicKeyInput; nextRow; 
+		build: [ :builder | builder
+			add: publicKeyLabel; add: publicKeyInput; nextRow;
 			add: privateKeyLabel; add: privateKeyInput; nextRow;
 			add: passphraseLabel; add: passphraseInput; nextRow ];
 		yourself
@@ -37,16 +36,14 @@ IceTipEditSSHCredentialsModel >> initialExtentForWindow [
 IceTipEditSSHCredentialsModel >> refreshCredentialsFromPresenter [
 
 	credentials
-		username: self username;
 		publicKey: self publicKey;
 		privateKey: self privateKey;
 		keyPassphrase: self passphrase
 ]
 
-{ #category : #accessing }
+{ #category : #actions }
 IceTipEditSSHCredentialsModel >> refreshPresenterFromCredentials [
 
-	usernameInput text: credentials username.
 	passphraseInput text: credentials keyPassphrase.
 	privateKeyInput location: credentials privateKey.
 	publicKeyInput location: credentials publicKey


### PR DESCRIPTION
The username of the SSH credential should come from the SSH URL not from the configuration.

- Fixing the presenters
- Fixing cancel when editing.

Fix #1686