### PR TITLE
Feature/multibyte commit message fix

### DIFF
--- a/Iceberg-Libgit/IceGitIndex.class.st
+++ b/Iceberg-Libgit/IceGitIndex.class.st
@@ -42,7 +42,7 @@ IceGitIndex >> commitWithMessage: message andParents: parentCommits [
 		index free.
 		commitId := (LGitCommitBuilder of: self repositoryHandle)
 			tree: (LGitTree of: self repositoryHandle fromId: indexTreeId);
-			message: message withUnixLineEndings utf8Encoded asString "FFI is expecting an string";
+			message: message withUnixLineEndings "FFI is expecting an string";
 			parents:
 				(self repositoryHandle isUnborn
 					ifTrue: [ #() ]

--- a/Iceberg-Tests/IceGitCommitMessageTest.class.st
+++ b/Iceberg-Tests/IceGitCommitMessageTest.class.st
@@ -25,6 +25,15 @@ IceGitCommitMessageTest >> testCommitNullString [
 ]
 
 { #category : #tests }
+IceGitCommitMessageTest >> testCommitWideString [
+	| msg |
+	msg := ZnUTF8Encoder new decodeBytes: (ByteArray readHexFrom: 'e38182e38184e38186'). "Japanese vowels a,i, and u - 'あいう'"
+	self repository commitWithMessage: msg.
+	self assert: self repository head commit comment equals: msg.
+
+]
+
+{ #category : #tests }
 IceGitCommitMessageTest >> testCommitWithEndingPesosSign [
 	"We used to have a problem that in some messages (depending of padding) the $ was added at the end"
 	| msg |


### PR DESCRIPTION
Please see the issue at: https://github.com/pharo-project/pharo/issues/13925

- Includes the suggested patch
- Added a test method for WideString commit message