### PR TITLE
#mergeStateWith: has no senders, but sends selectors that do not exist

### DIFF
--- a/Iceberg/IceAttachedSingleVersionWorkingCopy.class.st
+++ b/Iceberg/IceAttachedSingleVersionWorkingCopy.class.st
@@ -55,12 +55,6 @@ IceAttachedSingleVersionWorkingCopy >> mergeCommit: mergeCommit [
 		execute.
 ]
 
-{ #category : #merging }
-IceAttachedSingleVersionWorkingCopy >> mergeStateWith: aMergeableState [
-	
-	^ aMergeableState mergeWithSingleVersionWorkingCopyState: self
-]
-
 { #category : #accessing }
 IceAttachedSingleVersionWorkingCopy >> singleCommit [
 	

--- a/Iceberg/IceEmptyWorkingCopy.class.st
+++ b/Iceberg/IceEmptyWorkingCopy.class.st
@@ -4,7 +4,7 @@ I am an empty working copy, with no loaded packages.
 Class {
 	#name : #IceEmptyWorkingCopy,
 	#superclass : #IceWorkingCopyState,
-	#category : 'Iceberg-WorkingCopy'
+	#category : #'Iceberg-WorkingCopy'
 }
 
 { #category : #display }
@@ -17,12 +17,6 @@ IceEmptyWorkingCopy >> description [
 IceEmptyWorkingCopy >> isDetached [
 	"I have no reference commit, I cannot be detached"
 	^ false
-]
-
-{ #category : #merging }
-IceEmptyWorkingCopy >> mergeStateWith: aMergeableState [
-	
-	^ aMergeableState mergeWithEmptyWorkingCopyState: self
 ]
 
 { #category : #accessing }

--- a/Iceberg/IceInMergeWorkingCopy.class.st
+++ b/Iceberg/IceInMergeWorkingCopy.class.st
@@ -4,7 +4,7 @@ I am a working copy whose packages are all in merge status in the same commits.
 Class {
 	#name : #IceInMergeWorkingCopy,
 	#superclass : #IceWorkingCopyState,
-	#category : 'Iceberg-WorkingCopy'
+	#category : #'Iceberg-WorkingCopy'
 }
 
 { #category : #display }
@@ -23,12 +23,6 @@ IceInMergeWorkingCopy >> isDetached [
 IceInMergeWorkingCopy >> isInMerge [
 	
 	^ true
-]
-
-{ #category : #merging }
-IceInMergeWorkingCopy >> mergeStateWith: aMergeableState [
-	
-	^ aMergeableState mergeWithInMergeWorkingCopyState: self
 ]
 
 { #category : #accessing }

--- a/Iceberg/IceWorkingCopyState.class.st
+++ b/Iceberg/IceWorkingCopyState.class.st
@@ -66,12 +66,6 @@ IceWorkingCopyState >> mergeCommit: aCommit [
 	self subclassResponsibility
 ]
 
-{ #category : #merging }
-IceWorkingCopyState >> mergeStateWith: aMergeableState [
-	
-	self subclassResponsibility
-]
-
 { #category : #accessing }
 IceWorkingCopyState >> referenceCommit [
 	


### PR DESCRIPTION
... slowly cleaning up all methods showing in 

```
SystemNavigation new allSentNotImplementedSelectors 
```

#mergeStateWith: has no senders, but sends selectors that do not exist (like #mergeWithInMergeWorkingCopyState:)