### PR TITLE
Small cleaning in Monticello API

### DIFF
--- a/Iceberg/Iceberg.class.st
+++ b/Iceberg/Iceberg.class.st
@@ -123,21 +123,18 @@ Iceberg class >> remoteTypeSelector: anObject [
 ]
 
 { #category : #accessing }
-Iceberg class >> repositoryForPackage: anRPackage [ 
-	| existingRepositories possibleRepositoryTypes |
-	
-	existingRepositories := (MCWorkingCopy forPackage: anRPackage mcPackage) repositoryGroup repositories.
-	possibleRepositoryTypes := IceRepository allSubclasses, 
-		{ IceMetacelloRepositoryAdapter. 
-		  MCGitHubRepository }.
-	
-	possibleRepositoryTypes do: [ :class |
-		existingRepositories 
-			detect: [ :repo | repo isKindOf: class ]
-			ifFound: [ : repo |  ^ repo getOrCreateIcebergRepository ] ].
+Iceberg class >> repositoryForPackage: anRPackage [
 
-	self error: ('Could not find a git repository for {1}' format: {anRPackage name})
-	
+	| existingRepositories possibleRepositoryTypes |
+	existingRepositories := anRPackage mcWorkingCopy repositoryGroup repositories.
+	possibleRepositoryTypes := IceRepository allSubclasses , { IceMetacelloRepositoryAdapter . MCGitHubRepository }.
+
+	possibleRepositoryTypes do: [ :class |
+		existingRepositories
+			detect: [ :repo | repo isKindOf: class ]
+			ifFound: [ :repo | ^ repo getOrCreateIcebergRepository ] ].
+
+	self error: ('Could not find a git repository for {1}' format: { anRPackage name })
 ]
 
 { #category : #settings }


### PR DESCRIPTION
To get the working copy of a RPackage it is easier to call #mcWorkingCopy than to do what is actually done in the code. (#mcPackage will first get the working copy, so using the MC package to find the working copy end up doing 2 lookup of the working copy)