### PR TITLE
Do not use `RPackage organizer`

### DIFF
--- a/Iceberg-TipUI/IcePackageDefinition.extension.st
+++ b/Iceberg-TipUI/IcePackageDefinition.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #IcePackageDefinition }
 IcePackageDefinition >> browse [
 	"Open a browser on the package, if it exists."
 
-	(RPackage organizer packageNamed: name ifAbsent: [ ^ self ]) browse
+	(self packageOrganizer packageNamed: name ifAbsent: [ ^ self ]) browse
 ]
 
 { #category : #'*Iceberg-TipUI' }

--- a/Iceberg/IceCritiquesVisitor.class.st
+++ b/Iceberg/IceCritiquesVisitor.class.st
@@ -85,11 +85,10 @@ IceCritiquesVisitor >> visitNoModification: anIceNoModification [
 ]
 
 { #category : #visiting }
-IceCritiquesVisitor >> visitPackage: anIcePackageDefinition [ 
-	
+IceCritiquesVisitor >> visitPackage: anIcePackageDefinition [
+
 	| aPackage |
-	
-	aPackage := RPackage organizer packageNamed: anIcePackageDefinition name ifAbsent: [ ^ self ].
+	aPackage := self packageOrganizer packageNamed: anIcePackageDefinition name ifAbsent: [ ^ self ].
 	critiques addAll: aPackage critiques
 ]
 


### PR DESCRIPTION
This method emulates a dynamic global variable and is plan for deprecation. This PR provides an alternative way to access the organizer that does not contains the hacks of `RPackage organizer`.