### PR TITLE
Update tonel dependency to Pharo12 branch

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -2,12 +2,13 @@
 Baseline for https://github.com/pharo-vcs/iceberg project
 "
 Class {
-	#name : #BaselineOfIceberg,
-	#superclass : #BaselineOf,
-	#category : #BaselineOfIceberg
+	#name : 'BaselineOfIceberg',
+	#superclass : 'BaselineOf',
+	#category : 'BaselineOfIceberg',
+	#package : 'BaselineOfIceberg'
 }
 
-{ #category : #baseline }
+{ #category : 'baseline' }
 BaselineOfIceberg >> baseline: spec [
 	<baseline>
 	
@@ -63,14 +64,14 @@ BaselineOfIceberg >> baseline: spec [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BaselineOfIceberg >> customProjectAttributes [
 	Smalltalk os isMacOS ifTrue: [ ^ #(#MacOS) ].
 	Smalltalk os isUnix ifTrue: [ ^ #(#Unix) ].
 	Smalltalk os isWindows ifTrue: [ ^ #(#Windows) ]
 ]
 
-{ #category : #baseline }
+{ #category : 'baseline' }
 BaselineOfIceberg >> libgit: spec [
 	spec 
 		baseline: 'LibGit' 
@@ -84,14 +85,14 @@ BaselineOfIceberg >> libgit: spec [
 		with: [ spec loads: #('tests') ]
 ]
 
-{ #category : #script }
+{ #category : 'script' }
 BaselineOfIceberg >> postLoad [
 
 	self resetKMRepository.
 	(Smalltalk at: #Iceberg) bootstrap
 ]
 
-{ #category : #script }
+{ #category : 'script' }
 BaselineOfIceberg >> postLoadWithDirective: aDirective projectSpec: aSpec [
 	| repository |
 	self resetKMRepository.
@@ -108,7 +109,7 @@ BaselineOfIceberg >> postLoadWithDirective: aDirective projectSpec: aSpec [
 		packageList: aSpec packageNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BaselineOfIceberg >> projectClass [
 	^ super projectClass 
 	"this is breaking the bootstrap. Reverting it for now."
@@ -117,23 +118,23 @@ BaselineOfIceberg >> projectClass [
 		do: [ super projectClass ]"
 ]
 
-{ #category : #script }
+{ #category : 'script' }
 BaselineOfIceberg >> resetKMRepository [
 	Smalltalk 
 		at: #KMRepository 
 		ifPresent: [ :class | class reset ]
 ]
 
-{ #category : #baseline }
+{ #category : 'baseline' }
 BaselineOfIceberg >> ring2: spec [
 	spec
 		baseline: 'Ring2'
 		with: [ spec repository: 'github://guillep/Ring2:v2.0.0/src' ]
 ]
 
-{ #category : #baseline }
+{ #category : 'baseline' }
 BaselineOfIceberg >> tonel: spec [
 	spec
 		baseline: 'Tonel' 
-		with: [ spec repository: 'github://pharo-vcs/tonel:v1.0.19' ]
+		with: [ spec repository: 'github://pharo-vcs/tonel:Pharo12' ]
 ]

--- a/BaselineOfIceberg/package.st
+++ b/BaselineOfIceberg/package.st
@@ -1,1 +1,1 @@
-Package { #name : #BaselineOfIceberg }
+Package { #name : 'BaselineOfIceberg' }

--- a/Iceberg-UI-Tests/IceRegistryTest.class.st
+++ b/Iceberg-UI-Tests/IceRegistryTest.class.st
@@ -1,25 +1,26 @@
 Class {
-	#name : #IceRegistryTest,
-	#superclass : #TestCase,
+	#name : 'IceRegistryTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'currentRegistry'
 	],
-	#category : #'Iceberg-UI-Tests'
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceRegistryTest >> setUp [
 	super setUp.
 	currentRegistry := IceRepository registry.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceRegistryTest >> tearDown [
 	currentRegistry collect: [ :repo | repo ] into: IceRepository registry.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceRegistryTest >> testRegistryResetDoesNotThrowErrorUponOpenningWindow [
 	| window |
 	IceRepository reset.

--- a/Iceberg-UI-Tests/IceTipAskForPlaintextCredentialsModelTest.class.st
+++ b/Iceberg-UI-Tests/IceTipAskForPlaintextCredentialsModelTest.class.st
@@ -1,34 +1,36 @@
 Class {
-	#name : #IceTipAskForPlaintextCredentialsModelTest,
-	#superclass : #TestCase,
+	#name : 'IceTipAskForPlaintextCredentialsModelTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'store',
 		'dialog'
 	],
-	#category : #'Iceberg-UI-Tests'
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipAskForPlaintextCredentialsModelTest >> openNonModal: aDialog [
 	
 	aDialog asDialogWindow open
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipAskForPlaintextCredentialsModelTest >> setUp [
+
 	super setUp.
 	store := IceCredentialStore new.
-	dialog := IceTipAskForPlaintextCredentialsModel new
-		credentialStore: store;
-		yourself
+	dialog := IceTipAskForPlaintextCredentialsPresenter new
+		          credentialStore: store;
+		          yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipAskForPlaintextCredentialsModelTest >> tearDown [
 	dialog ifNotNil: [ [dialog window close] on: LGitNoCredentialsProvided do: [  ] ].
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipAskForPlaintextCredentialsModelTest >> testAcceptCreatesCredential [
 
 	| cred |
@@ -46,7 +48,7 @@ IceTipAskForPlaintextCredentialsModelTest >> testAcceptCreatesCredential [
 	self assert: cred password equals: 'aaa'.	
 ]
 
-{ #category : #'tests - storing' }
+{ #category : 'tests - storing' }
 IceTipAskForPlaintextCredentialsModelTest >> testAcceptDoNotStoresCredential [
 	| cred |
 	
@@ -65,7 +67,7 @@ IceTipAskForPlaintextCredentialsModelTest >> testAcceptDoNotStoresCredential [
 	self assert: cred password equals: ''.		
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipAskForPlaintextCredentialsModelTest >> testAcceptEnabledAndDisabled [
 	dialog askingHostname: 'github.com'.
 	self openNonModal: dialog. 
@@ -83,14 +85,14 @@ IceTipAskForPlaintextCredentialsModelTest >> testAcceptEnabledAndDisabled [
 	self assert: dialog okButton isEnabled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipAskForPlaintextCredentialsModelTest >> testAcceptIsBlockedInTheBeginning [
 	dialog askingHostname: 'github.com'.
 	self openNonModal: dialog. 
 	self deny: dialog okButton isEnabled
 ]
 
-{ #category : #'tests - storing' }
+{ #category : 'tests - storing' }
 IceTipAskForPlaintextCredentialsModelTest >> testAcceptStoresCredential [
 
 	| cred |
@@ -109,7 +111,7 @@ IceTipAskForPlaintextCredentialsModelTest >> testAcceptStoresCredential [
 	self assert: cred password equals: 'aaa'.		
 ]
 
-{ #category : #'tests - storing' }
+{ #category : 'tests - storing' }
 IceTipAskForPlaintextCredentialsModelTest >> testAcceptStoresCredentialReplacesOld [
 
 	| cred orig |
@@ -132,7 +134,7 @@ IceTipAskForPlaintextCredentialsModelTest >> testAcceptStoresCredentialReplacesO
 	self assert: cred password equals: 'aaa'.		
 ]
 
-{ #category : #'tests - cancel' }
+{ #category : 'tests - cancel' }
 IceTipAskForPlaintextCredentialsModelTest >> testCancelThrowsException [
 
 	dialog askingHostname: 'github.com'. 
@@ -141,7 +143,7 @@ IceTipAskForPlaintextCredentialsModelTest >> testCancelThrowsException [
 	self should: [ dialog window triggerCancelAction ] raise: LGitNoCredentialsProvided
 ]
 
-{ #category : #'tests - cancel' }
+{ #category : 'tests - cancel' }
 IceTipAskForPlaintextCredentialsModelTest >> testCloseThrowsException [
 
 	dialog askingHostname: 'github.com'. 
@@ -150,7 +152,7 @@ IceTipAskForPlaintextCredentialsModelTest >> testCloseThrowsException [
 	self should: [ dialog window close ] raise: LGitNoCredentialsProvided
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipAskForPlaintextCredentialsModelTest >> testTitle [
 
 	dialog askingHostname: 'github.com'. 

--- a/Iceberg-UI-Tests/IceTipCollectionRepositoryProvider.class.st
+++ b/Iceberg-UI-Tests/IceTipCollectionRepositoryProvider.class.st
@@ -1,24 +1,25 @@
 Class {
-	#name : #IceTipCollectionRepositoryProvider,
-	#superclass : #Object,
+	#name : 'IceTipCollectionRepositoryProvider',
+	#superclass : 'Object',
 	#instVars : [
 		'collection'
 	],
-	#category : #'Iceberg-UI-Tests'
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IceTipCollectionRepositoryProvider >> addRepository: aRepository [
 	
 	collection add: aRepository
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IceTipCollectionRepositoryProvider >> collection: anObject [
 	collection := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IceTipCollectionRepositoryProvider >> repositories [
 
 	^ collection

--- a/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #IceTipCommitBrowserTest,
-	#superclass : #IceAbstractTestCase,
+	#name : 'IceTipCommitBrowserTest',
+	#superclass : 'IceAbstractTestCase',
 	#instVars : [
 		'presenter',
 		'saveMock'
 	],
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipCommitBrowserTest class >> isAbstract [
 	^ self name = #IceTipCommitBrowserTest
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipCommitBrowserTest >> setUp [
 
 	super setUp.
@@ -35,13 +37,13 @@ IceTipCommitBrowserTest >> setUp [
 	presenter commentPanel commentText text: 'my super commit message'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipCommitBrowserTest >> tearDown [
 	presenter ifNotNil: [ presenter window close ].
 	super tearDown 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testAcceptShortcutInCommentBoxTriggersCommit [
 	| oldStatus |
 	
@@ -61,7 +63,7 @@ IceTipCommitBrowserTest >> testAcceptShortcutInCommentBoxTriggersCommit [
 		presenter commentPanel saveOnCommit: oldStatus ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testFixesField [
 	self
 		assert: presenter commentPanel fixesField class
@@ -78,7 +80,7 @@ IceTipCommitBrowserTest >> testFixesField [
 Fixes #123456'.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testHasCommentPanelWithSavingSettings [
 	| previousState |
 	
@@ -96,13 +98,13 @@ IceTipCommitBrowserTest >> testHasCommentPanelWithSavingSettings [
 		presenter commentPanel saveOnCommit: previousState ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testHasDiffPanel [
 	self
 		assert: presenter diffPanel class equals: IceTipDiffSelectingPanel 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testIsAutomaticallySavingWhenChecked [
 	| previousState|
 	
@@ -116,7 +118,7 @@ IceTipCommitBrowserTest >> testIsAutomaticallySavingWhenChecked [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testIsCommitingCheckedItems [
 	| diffTree |
 
@@ -141,7 +143,7 @@ IceTipCommitBrowserTest >> testIsCommitingCheckedItems [
 				isMethodDefinition
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testIsCommitingWithTheRightMessage [
 	presenter doCommit.
 	self
@@ -149,7 +151,7 @@ IceTipCommitBrowserTest >> testIsCommitingWithTheRightMessage [
 		equals: 'my super commit message'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testIsNotAutomaticallySavingWhenNotChecked [
 	| previousState |
 	previousState := presenter commentPanel isSaving.
@@ -161,7 +163,7 @@ IceTipCommitBrowserTest >> testIsNotAutomaticallySavingWhenNotChecked [
 		presenter commentPanel saveOnCommit: previousState ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTest >> testIsNotCommitingUncheckedItems [
 	| diffTree |
 	presenter diffPanel selectedItems

--- a/Iceberg-UI-Tests/IceTipCommitBrowserTestWithRemoteSet.class.st
+++ b/Iceberg-UI-Tests/IceTipCommitBrowserTestWithRemoteSet.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #IceTipCommitBrowserTestWithRemoteSet,
-	#superclass : #IceTipCommitBrowserTest,
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#name : 'IceTipCommitBrowserTestWithRemoteSet',
+	#superclass : 'IceTipCommitBrowserTest',
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipCommitBrowserTestWithRemoteSet >> newFixture [
 	^ IceClonedFromRemoteFixture inGit
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTestWithRemoteSet >> testNotPushingAutomatically [
 	| previousState |
 	previousState := presenter commentPanel isPushing.
@@ -19,7 +21,7 @@ IceTipCommitBrowserTestWithRemoteSet >> testNotPushingAutomatically [
 	presenter commentPanel pushCheckbox state: previousState
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTestWithRemoteSet >> testPushSettingCheckbox [
 	| previousState |
 
@@ -34,7 +36,7 @@ IceTipCommitBrowserTestWithRemoteSet >> testPushSettingCheckbox [
 	presenter commentPanel pushCheckbox toggleState
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTestWithRemoteSet >> testPushingAutomatically [
 	| previousState diffTree |
 	previousState := presenter commentPanel isPushing.

--- a/Iceberg-UI-Tests/IceTipCommitBrowserTestWithoutRemoteSet.class.st
+++ b/Iceberg-UI-Tests/IceTipCommitBrowserTestWithoutRemoteSet.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #IceTipCommitBrowserTestWithoutRemoteSet,
-	#superclass : #IceTipCommitBrowserTest,
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#name : 'IceTipCommitBrowserTestWithoutRemoteSet',
+	#superclass : 'IceTipCommitBrowserTest',
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipCommitBrowserTestWithoutRemoteSet >> newFixture [
 	^ IceCleanWorkingCopyFixture inGit
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCommitBrowserTestWithoutRemoteSet >> testPushSettingCheckbox [
 	self assert: presenter commentPanel isPushing equals: false
 ]

--- a/Iceberg-UI-Tests/IceTipCreateTagPanelTest.class.st
+++ b/Iceberg-UI-Tests/IceTipCreateTagPanelTest.class.st
@@ -1,33 +1,34 @@
 Class {
-	#name : #IceTipCreateTagPanelTest,
-	#superclass : #TestCase,
+	#name : 'IceTipCreateTagPanelTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'panel'
 	],
-	#category : 'Iceberg-UI-Tests'
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCreateTagPanelTest >> testLatestTagPartsNoNumeric [
 	panel := IceTipCreateTagPanel basicNew.
 	self assert: (panel latestTagPartsIn: #()) equals: #('v' 0 0 0).
 	self assert: (panel latestTagPartsIn: #('non-numeric')) equals: #('v' 0 0 0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCreateTagPanelTest >> testLatestTagPartsNoNumeric2 [
 	panel := IceTipCreateTagPanel basicNew.
 	self assert: (panel latestTagPartsIn: #('v1.2.x')) equals: #('v' 1 2 0).
 	self assert: (panel latestTagPartsIn: #('v1.x')) equals: #('v' 1 0 0).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCreateTagPanelTest >> testLatestTagPartsPadded [
 	panel := IceTipCreateTagPanel basicNew.
 	self assert: (panel latestTagPartsIn: #('v2.1')) equals: #('v' 2 1 0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCreateTagPanelTest >> testLatestTagPartsWithExtra [
 	panel := IceTipCreateTagPanel basicNew.
 	self
@@ -35,7 +36,7 @@ IceTipCreateTagPanelTest >> testLatestTagPartsWithExtra [
 		equals: #('v' 1 0 3)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCreateTagPanelTest >> testLatestTagPartsWithPrefix [
 	panel := IceTipCreateTagPanel basicNew.
 	self
@@ -43,7 +44,7 @@ IceTipCreateTagPanelTest >> testLatestTagPartsWithPrefix [
 		equals: #('v' 2 1 3)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipCreateTagPanelTest >> testLatestTagPartsWithoutPrefix [
 	panel := IceTipCreateTagPanel basicNew.
 	self

--- a/Iceberg-UI-Tests/IceTipEditProjectDialogTest.class.st
+++ b/Iceberg-UI-Tests/IceTipEditProjectDialogTest.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #IceTipEditProjectDialogTest,
-	#superclass : #IceAbstractTestCase,
+	#name : 'IceTipEditProjectDialogTest',
+	#superclass : 'IceAbstractTestCase',
 	#instVars : [
 		'dialog'
 	],
-	#category : #'Iceberg-UI-Tests'
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipEditProjectDialogTest class >> isAbstract [
 	^ self name = #IceTipEditProjectDialogTest
 ]

--- a/Iceberg-UI-Tests/IceTipEditProjectDialogWithPackageInWorkingCopyTest.class.st
+++ b/Iceberg-UI-Tests/IceTipEditProjectDialogWithPackageInWorkingCopyTest.class.st
@@ -1,5 +1,6 @@
 Class {
-	#name : #IceTipEditProjectDialogWithPackageInWorkingCopyTest,
-	#superclass : #IceTipEditProjectDialogTest,
-	#category : #'Iceberg-UI-Tests'
+	#name : 'IceTipEditProjectDialogWithPackageInWorkingCopyTest',
+	#superclass : 'IceTipEditProjectDialogTest',
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }

--- a/Iceberg-UI-Tests/IceTipEditProjectDialogWithoutPackageInWorkingCopyTest.class.st
+++ b/Iceberg-UI-Tests/IceTipEditProjectDialogWithoutPackageInWorkingCopyTest.class.st
@@ -1,5 +1,6 @@
 Class {
-	#name : #IceTipEditProjectDialogWithoutPackageInWorkingCopyTest,
-	#superclass : #IceTipEditProjectDialogTest,
-	#category : #'Iceberg-UI-Tests'
+	#name : 'IceTipEditProjectDialogWithoutPackageInWorkingCopyTest',
+	#superclass : 'IceTipEditProjectDialogTest',
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }

--- a/Iceberg-UI-Tests/IceTipHistoryBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipHistoryBrowserTest.class.st
@@ -1,18 +1,20 @@
 Class {
-	#name : #IceTipHistoryBrowserTest,
-	#superclass : #IceAbstractTestCase,
+	#name : 'IceTipHistoryBrowserTest',
+	#superclass : 'IceAbstractTestCase',
 	#instVars : [
 		'presenter'
 	],
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipHistoryBrowserTest >> newFixture [
 	^ IceWithRemoteAndLocalCommitFixture inGit
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipHistoryBrowserTest >> setUp [
 
 	| model iceTipPullModel |
@@ -25,13 +27,13 @@ IceTipHistoryBrowserTest >> setUp [
 	presenter open
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipHistoryBrowserTest >> tearDown [
 	presenter ifNotNil: [ presenter window close ].
 	super tearDown 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipHistoryBrowserTest >> testCommitListDisplayData [
 	| commit |
 	commit := (presenter commitList items at: 1) realObject.
@@ -49,12 +51,12 @@ IceTipHistoryBrowserTest >> testCommitListDisplayData [
 		equals: commit datetime asLocalStringYMDHM
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipHistoryBrowserTest >> testCommitListHasTheCorrectColumns [
 	self assertCollection: (presenter commitList columns collect: #title ) hasSameElements:  { 'Timestamp' . 'Commit' . 'Author' . 'Description'}
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipHistoryBrowserTest >> testHasDiffPanel [
 	self
 		assert: presenter commitInfoTabs class = IceTipCommitInfoPresenter

--- a/Iceberg-UI-Tests/IceTipMockSaveImageAction.class.st
+++ b/Iceberg-UI-Tests/IceTipMockSaveImageAction.class.st
@@ -1,26 +1,28 @@
 Class {
-	#name : #IceTipMockSaveImageAction,
-	#superclass : #Object,
+	#name : 'IceTipMockSaveImageAction',
+	#superclass : 'Object',
 	#instVars : [
 		'timesExecuted'
 	],
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IceTipMockSaveImageAction >> execute [
 
 	timesExecuted := timesExecuted + 1
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IceTipMockSaveImageAction >> initialize [ 
 
 	super initialize.
 	timesExecuted := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IceTipMockSaveImageAction >> timesExecuted [
 	^timesExecuted 
 ]

--- a/Iceberg-UI-Tests/IceTipPresenterMetaTests.class.st
+++ b/Iceberg-UI-Tests/IceTipPresenterMetaTests.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #IceTipPresenterMetaTests,
-	#superclass : #TestCase,
-	#category : #'Iceberg-UI-Tests'
+	#name : 'IceTipPresenterMetaTests',
+	#superclass : 'TestCase',
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipPresenterMetaTests >> allClassesInAnyIcebergPackage [
 
 	^ Array streamContents: [ :str | 
@@ -12,7 +13,7 @@ IceTipPresenterMetaTests >> allClassesInAnyIcebergPackage [
 			  (c package name beginsWith: 'Iceberg') ifTrue: [ str nextPut: c ] ] ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipPresenterMetaTests >> allMethodsInPresenters [
 	
 	^ Array streamContents: [ :stream |
@@ -22,7 +23,7 @@ IceTipPresenterMetaTests >> allMethodsInPresenters [
 			 	nextPutAll: each classSide methods ] ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipPresenterMetaTests >> allMethodsInPresentersThatMatch: aRBPattern [
 
 	| searcher |
@@ -37,7 +38,7 @@ IceTipPresenterMetaTests >> allMethodsInPresentersThatMatch: aRBPattern [
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipPresenterMetaTests >> assertSendSuperAllMethodsNamed: aSelector isMeta: isMeta [
 
 	| aCollection |
@@ -56,7 +57,7 @@ IceTipPresenterMetaTests >> assertSendSuperAllMethodsNamed: aSelector isMeta: is
 	"
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipPresenterMetaTests >> methodsInPresentersWithName: aSelector isMeta: isMeta [
 
 	^ Array streamContents: [ :stream |
@@ -67,21 +68,21 @@ IceTipPresenterMetaTests >> methodsInPresentersWithName: aSelector isMeta: isMet
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipPresenterMetaTests >> presenterClasses [
 
 	^ self allClassesInAnyIcebergPackage select: [ :each | 
 		  each inheritsFrom: SpPresenter ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipPresenterMetaTests >> presenterClassesDefining: aSelector isMeta: isMeta [
 
 	^ (self methodsInPresentersWithName: aSelector isMeta: isMeta)
 		collect: [ :each | each origin ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipPresenterMetaTests >> testDefaultSpecDoesntUsePragma [
 	"Do not use the <spec> pragma, that was necessary in Spec1 but not in Spec2."
 
@@ -92,7 +93,7 @@ IceTipPresenterMetaTests >> testDefaultSpecDoesntUsePragma [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipPresenterMetaTests >> testDoNotImplementDiscouragedSelectors [
 
 	"Either instance or class-side, the old #title is named #titleForWindow in inst-side."
@@ -112,7 +113,7 @@ IceTipPresenterMetaTests >> testDoNotImplementDiscouragedSelectors [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipPresenterMetaTests >> testDontAccessUnderlyingWidget [
 	"In general, we don't want uses of #whenBuiltDo: or #adapter or similar. 
 	They are not prohibited by Spec2, but they are often used to manipulate the
@@ -130,7 +131,7 @@ IceTipPresenterMetaTests >> testDontAccessUnderlyingWidget [
 	"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipPresenterMetaTests >> testPreferCloseWindow [
 	"IceTipSpPresenter provides #closeWindow to avoid 'self window close' and 'self window delete'."
 

--- a/Iceberg-UI-Tests/IceTipRepositoriesBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipRepositoriesBrowserTest.class.st
@@ -1,27 +1,29 @@
 Class {
-	#name : #IceTipRepositoriesBrowserTest,
-	#superclass : #IceAbstractTestCase,
+	#name : 'IceTipRepositoriesBrowserTest',
+	#superclass : 'IceAbstractTestCase',
 	#instVars : [
 		'presenter',
 		'alphabeticallyFirstRepository',
 		'repositoryProvider'
 	],
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipRepositoriesBrowserTest >> newFixture [
 	
 	^ IceSinglePackageFixture inGit
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoriesBrowserTest >> newRepositoryNamed: aName [
 
 	^ fixture factory newRepositoryNamed: aName
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoriesBrowserTest >> setUp [
 
 	| alphabeticallyLastRepository |
@@ -42,12 +44,12 @@ IceTipRepositoriesBrowserTest >> setUp [
 	presenter open
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoriesBrowserTest >> tearDown [
 	presenter ifNotNil: [ presenter window close ]. super tearDown
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testAddRepositoryInModelWithoutRefreshDoesNotRefreshList [
 	
 	| previousList |
@@ -58,7 +60,7 @@ IceTipRepositoriesBrowserTest >> testAddRepositoryInModelWithoutRefreshDoesNotRe
 	self assert: presenter projectsPanelRepositoryList items equals: previousList.
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testAddRepositoryInModelWithoutRefreshDoesNotShowNewRepository [
 	
 	| newRepository |
@@ -68,7 +70,7 @@ IceTipRepositoriesBrowserTest >> testAddRepositoryInModelWithoutRefreshDoesNotSh
 	self deny: (presenter projectsPanelIsShowingRepository: newRepository)
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testAddRepositoryThenRefreshShowsNewRepository [
 	
 	| newRepository |
@@ -79,7 +81,7 @@ IceTipRepositoriesBrowserTest >> testAddRepositoryThenRefreshShowsNewRepository 
 	self assert: (presenter projectsPanelIsShowingRepository: newRepository)
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditRepositoryBranchThenRefreshDoesRefreshList [
 	
 	self
@@ -88,7 +90,7 @@ IceTipRepositoriesBrowserTest >> testEditRepositoryBranchThenRefreshDoesRefreshL
 		makesPropertyValueTo: 'toto'
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditRepositoryBranchWithoutRefreshDoesNotRefreshList [
 		
 	self
@@ -96,7 +98,7 @@ IceTipRepositoriesBrowserTest >> testEditRepositoryBranchWithoutRefreshDoesNotRe
 		doing: [ :repository | repository createBranch: 'toto' ]
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditRepositoryNameThenRefreshDoesRefreshList [
 	
 	| newName |	
@@ -107,7 +109,7 @@ IceTipRepositoriesBrowserTest >> testEditRepositoryNameThenRefreshDoesRefreshLis
 		makesPropertyValueTo: newName
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditRepositoryNameWithoutRefreshDoesNotRefreshList [
 	
 	self
@@ -115,7 +117,7 @@ IceTipRepositoriesBrowserTest >> testEditRepositoryNameWithoutRefreshDoesNotRefr
 		doing: [ :repository | repository name: 'newname' ]
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditRepositoryProperty: aProperty doing: aBlock makesPropertyValueTo: aValue [
 	| firstRepository repositoryModel oldValue newValue |	
 
@@ -133,7 +135,7 @@ IceTipRepositoriesBrowserTest >> testEditRepositoryProperty: aProperty doing: aB
 	self assert: newValue equals: aValue.
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditRepositoryStatusThenRefreshDoesRefreshList [
 	
 	self
@@ -144,7 +146,7 @@ IceTipRepositoriesBrowserTest >> testEditRepositoryStatusThenRefreshDoesRefreshL
 		makesPropertyValueTo: (IceTipRepositoryModel on: nil) localRepositoryMissing
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditRepositoryStatusWithoutRefreshDoesNotRefreshList [
 	
 	self
@@ -154,7 +156,7 @@ IceTipRepositoriesBrowserTest >> testEditRepositoryStatusWithoutRefreshDoesNotRe
 			repository repositoryDirectory ensureDeleteAll ]
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditThenRefreshRepositoryProperty: aProperty doing: aBlock makesPropertyValueTo: aValue [
 
 	self
@@ -165,7 +167,7 @@ IceTipRepositoriesBrowserTest >> testEditThenRefreshRepositoryProperty: aPropert
 		makesPropertyValueTo: aValue
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testEditWithoutRefreshRepositoryProperty: aProperty doing: aBlock [
 	
 	| repositoryModel |
@@ -176,25 +178,25 @@ IceTipRepositoriesBrowserTest >> testEditWithoutRefreshRepositoryProperty: aProp
 		makesPropertyValueTo: (repositoryModel perform: aProperty)
 ]
 
-{ #category : #'tests - structural' }
+{ #category : 'tests - structural' }
 IceTipRepositoriesBrowserTest >> testHasAddButtonOnTheRight [
 
 	self assert: (presenter toolbar rightItems anySatisfy: [:aButton | aButton label = 'Add']).
 ]
 
-{ #category : #'tests - structural' }
+{ #category : 'tests - structural' }
 IceTipRepositoriesBrowserTest >> testHasFetchAllButtonOnTheLeft [
 
 	self assert: (presenter toolbar leftItems anySatisfy: [:aButton | aButton label = 'Fetch all']).
 ]
 
-{ #category : #'tests - structural' }
+{ #category : 'tests - structural' }
 IceTipRepositoriesBrowserTest >> testHasSettingsButtonOnTheRight [
 
 	self assert: (presenter toolbar rightItems anySatisfy: [:aButton | aButton label = 'Settings']).
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testInitialListShowsElementsInOriginalOrder [
 	
 	self
@@ -208,7 +210,7 @@ IceTipRepositoriesBrowserTest >> testInitialListShowsElementsInOriginalOrder [
 		equals: presenter projectsPanelRepositoryList items third description.
 ]
 
-{ #category : #'tests - context menu' }
+{ #category : 'tests - context menu' }
 IceTipRepositoriesBrowserTest >> testListHasContextMenuHasPackagesOptionEnabled [
 	
 	| menu |
@@ -220,7 +222,7 @@ IceTipRepositoriesBrowserTest >> testListHasContextMenuHasPackagesOptionEnabled 
 	self assert: (menu defaultGroup menuItems at: 1) isEnabled
 ]
 
-{ #category : #'tests - context menu' }
+{ #category : 'tests - context menu' }
 IceTipRepositoriesBrowserTest >> testListHasContextMenuHasRepairRepositoryOptionDisabled [
 
 	| menu |
@@ -231,7 +233,7 @@ IceTipRepositoriesBrowserTest >> testListHasContextMenuHasRepairRepositoryOption
 			 each name = IceTipRepairCommand defaultName ])
 ]
 
-{ #category : #'tests - context menu' }
+{ #category : 'tests - context menu' }
 IceTipRepositoriesBrowserTest >> testListHasContextMenuOnSelection [
 
 	| menu |
@@ -242,7 +244,7 @@ IceTipRepositoriesBrowserTest >> testListHasContextMenuOnSelection [
 	self assert: menu defaultGroup menuItems isNotEmpty
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testListShowsNotLoadedProject [
 	
 	self assert: (presenter projectsPanelRepositoryList valueAtColumn: 1 row: 3) equals: '*anotherOne'.
@@ -250,7 +252,7 @@ IceTipRepositoriesBrowserTest >> testListShowsNotLoadedProject [
 	self assert: (presenter projectsPanelRepositoryList valueAtColumn: 3 row: 3) equals: 'master'.
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testListShowsUpToDateProject [
 
 	self assert: (presenter projectsPanelRepositoryList valueAtColumn: 1 row: 1) equals: 'test-project'.
@@ -258,28 +260,28 @@ IceTipRepositoriesBrowserTest >> testListShowsUpToDateProject [
 	self assert: (presenter projectsPanelRepositoryList valueAtColumn: 3 row: 1) equals: 'master'. 
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingByBranchDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 3
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingByNameDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 1.
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingByStatusDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 2
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingDescendingByBranchDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
@@ -287,7 +289,7 @@ IceTipRepositoriesBrowserTest >> testSortingDescendingByBranchDoesNotFail [
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 3.
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingDescendingByNameDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
@@ -295,7 +297,7 @@ IceTipRepositoriesBrowserTest >> testSortingDescendingByNameDoesNotFail [
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 1.
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingDescendingByStatusDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
@@ -303,7 +305,7 @@ IceTipRepositoriesBrowserTest >> testSortingDescendingByStatusDoesNotFail [
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 2.
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingOriginalByBranchDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
@@ -312,7 +314,7 @@ IceTipRepositoriesBrowserTest >> testSortingOriginalByBranchDoesNotFail [
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 3.
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingOriginalByNameDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
@@ -321,7 +323,7 @@ IceTipRepositoriesBrowserTest >> testSortingOriginalByNameDoesNotFail [
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 1.
 ]
 
-{ #category : #'tests - table sorting' }
+{ #category : 'tests - table sorting' }
 IceTipRepositoriesBrowserTest >> testSortingOriginalByStatusDoesNotFail [
 	
 	"Smoke test because there is no way to access the real shown elements for now"
@@ -330,7 +332,7 @@ IceTipRepositoriesBrowserTest >> testSortingOriginalByStatusDoesNotFail [
 	presenter projectsPanelRepositoryList clickOnColumnHeaderAt: 2.
 ]
 
-{ #category : #'tests - table' }
+{ #category : 'tests - table' }
 IceTipRepositoriesBrowserTest >> testTableHasTheCorrectColumns [
 
 	self assertCollection: (presenter projectsPanelRepositoryList columns collect: #title) hasSameElements:  { 'Repositories'. 'Status'. 'Branch'}

--- a/Iceberg-UI-Tests/IceTipRepositoryBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipRepositoryBrowserTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #IceTipRepositoryBrowserTest,
-	#superclass : #IceAbstractTestCase,
+	#name : 'IceTipRepositoryBrowserTest',
+	#superclass : 'IceAbstractTestCase',
 	#instVars : [
 		'presenter'
 	],
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserTest class >> isAbstract [
 
 	^ self name = #IceTipRepositoryBrowserTest
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserTest >> testHasAddRemoteButtonOnTheRight [
 	self
 		assert:
@@ -21,7 +23,7 @@ IceTipRepositoryBrowserTest >> testHasAddRemoteButtonOnTheRight [
 				anySatisfy: [ :aButton | aButton label = 'Add remote' ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserTest >> testHasBranchButtonOnTheLeft [
 	self
 		assert:
@@ -29,7 +31,7 @@ IceTipRepositoryBrowserTest >> testHasBranchButtonOnTheLeft [
 				anySatisfy: [ :aButton | aButton label = 'Branch' ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserTest >> testHasCorrectSideTreeBar [
 	self
 		assertCollection: (presenter sidebarTree roots collect: #name)
@@ -37,13 +39,13 @@ IceTipRepositoryBrowserTest >> testHasCorrectSideTreeBar [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserTest >> testHasHiedraHistoryBrowser [
 
 	presenter historyPanel class = IceTipHiedraAltHistoryBrowser
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserTest >> testHasMergeButtonOnTheLeft [
 	self
 		assert:

--- a/Iceberg-UI-Tests/IceTipRepositoryBrowserWithRemoteTest.class.st
+++ b/Iceberg-UI-Tests/IceTipRepositoryBrowserWithRemoteTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #IceTipRepositoryBrowserWithRemoteTest,
-	#superclass : #IceTipRepositoryBrowserTest,
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#name : 'IceTipRepositoryBrowserWithRemoteTest',
+	#superclass : 'IceTipRepositoryBrowserTest',
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipRepositoryBrowserWithRemoteTest >> newFixture [
 	^ IceWithRemoteFixture inGit
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithRemoteTest >> setUp [
 
 	super setUp.
@@ -17,13 +19,13 @@ IceTipRepositoryBrowserWithRemoteTest >> setUp [
 	presenter open
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithRemoteTest >> tearDown [
 	presenter ifNotNil: [ "super tearDown" presenter window close ].
 	super tearDown.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithRemoteTest >> testHasFetchButtonOnTheLeft [
 	self
 		assert:
@@ -31,7 +33,7 @@ IceTipRepositoryBrowserWithRemoteTest >> testHasFetchButtonOnTheLeft [
 				anySatisfy: [ :aButton | aButton label = 'Fetch' ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithRemoteTest >> testHasPullButtonOnTheLeft [
 	self
 		assert:
@@ -39,7 +41,7 @@ IceTipRepositoryBrowserWithRemoteTest >> testHasPullButtonOnTheLeft [
 				anySatisfy: [ :aButton | aButton label = 'Pull' ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithRemoteTest >> testHasPushButtonOnTheLeft [
 	self
 		assert:

--- a/Iceberg-UI-Tests/IceTipRepositoryBrowserWithoutRemoteTest.class.st
+++ b/Iceberg-UI-Tests/IceTipRepositoryBrowserWithoutRemoteTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #IceTipRepositoryBrowserWithoutRemoteTest,
-	#superclass : #IceTipRepositoryBrowserTest,
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#name : 'IceTipRepositoryBrowserWithoutRemoteTest',
+	#superclass : 'IceTipRepositoryBrowserTest',
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipRepositoryBrowserWithoutRemoteTest >> newFixture [
 	
 	^ IceSinglePackageFixture inGit
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithoutRemoteTest >> setUp [
 
 	super setUp.
@@ -18,14 +20,14 @@ IceTipRepositoryBrowserWithoutRemoteTest >> setUp [
 	presenter open
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithoutRemoteTest >> tearDown [
 
 	presenter ifNotNil: [ presenter window close ]
 	"super tearDown"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithoutRemoteTest >> testHasNoFetchButtonOnTheLeft [
 	self
 		deny:
@@ -33,7 +35,7 @@ IceTipRepositoryBrowserWithoutRemoteTest >> testHasNoFetchButtonOnTheLeft [
 				anySatisfy: [ :aButton | aButton label = 'Fetch' ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithoutRemoteTest >> testHasNoPullButtonOnTheLeft [
 	self
 		deny:
@@ -41,7 +43,7 @@ IceTipRepositoryBrowserWithoutRemoteTest >> testHasNoPullButtonOnTheLeft [
 				anySatisfy: [ :aButton | aButton label = 'Pull' ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipRepositoryBrowserWithoutRemoteTest >> testHasNoPushButtonOnTheLeft [
 	self
 		deny:

--- a/Iceberg-UI-Tests/IceTipUnknownCommitRepositoryTest.class.st
+++ b/Iceberg-UI-Tests/IceTipUnknownCommitRepositoryTest.class.st
@@ -1,16 +1,17 @@
 Class {
-	#name : #IceTipUnknownCommitRepositoryTest,
-	#superclass : #IceAbstractTestCase,
-	#category : 'Iceberg-UI-Tests'
+	#name : 'IceTipUnknownCommitRepositoryTest',
+	#superclass : 'IceAbstractTestCase',
+	#category : 'Iceberg-UI-Tests',
+	#package : 'Iceberg-UI-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipUnknownCommitRepositoryTest >> newFixture [
 
 	^ IceWithRemoteAndUnknownCommitFixture inGit
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipUnknownCommitRepositoryTest >> testRepositoryStatusIsUnknown [
 
 	| model status |

--- a/Iceberg-UI-Tests/IceTipWorkingCopyBrowserOnDetachedRepoTest.class.st
+++ b/Iceberg-UI-Tests/IceTipWorkingCopyBrowserOnDetachedRepoTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #IceTipWorkingCopyBrowserOnDetachedRepoTest,
-	#superclass : #IceTipWorkingCopyBrowserTest,
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#name : 'IceTipWorkingCopyBrowserOnDetachedRepoTest',
+	#superclass : 'IceTipWorkingCopyBrowserTest',
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipWorkingCopyBrowserOnDetachedRepoTest >> newFixture [
 	
 	^ IceDetachedWorkingCopyFixture inGit
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipWorkingCopyBrowserOnDetachedRepoTest >> testStatusBarShowsStatusOfRepository [
 
 	self assert:

--- a/Iceberg-UI-Tests/IceTipWorkingCopyBrowserOnUpdatedRepoTest.class.st
+++ b/Iceberg-UI-Tests/IceTipWorkingCopyBrowserOnUpdatedRepoTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #IceTipWorkingCopyBrowserOnUpdatedRepoTest,
-	#superclass : #IceTipWorkingCopyBrowserTest,
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#name : 'IceTipWorkingCopyBrowserOnUpdatedRepoTest',
+	#superclass : 'IceTipWorkingCopyBrowserTest',
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipWorkingCopyBrowserOnUpdatedRepoTest >> newFixture [
 	
 	^ IceSinglePackageFixture inGit
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipWorkingCopyBrowserOnUpdatedRepoTest >> testStatusBarShowsStatusOfRepository [
 
 	self assert:

--- a/Iceberg-UI-Tests/IceTipWorkingCopyBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipWorkingCopyBrowserTest.class.st
@@ -1,26 +1,28 @@
 Class {
-	#name : #IceTipWorkingCopyBrowserTest,
-	#superclass : #IceAbstractTestCase,
+	#name : 'IceTipWorkingCopyBrowserTest',
+	#superclass : 'IceAbstractTestCase',
 	#instVars : [
 		'presenter'
 	],
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 IceTipWorkingCopyBrowserTest class >> isAbstract [
 
 	^ self name = #IceTipWorkingCopyBrowserTest 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipWorkingCopyBrowserTest >> contextMenuForIndex: index [
 
 	presenter packagesTable selectIndex: index.
 	^ presenter packagesTable contextMenu value.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipWorkingCopyBrowserTest >> setUp [
 
 	super setUp.
@@ -29,7 +31,7 @@ IceTipWorkingCopyBrowserTest >> setUp [
 	presenter open
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipWorkingCopyBrowserTest >> tearDown [
 
 	presenter ifNotNil: [ 
@@ -37,7 +39,7 @@ IceTipWorkingCopyBrowserTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipWorkingCopyBrowserTest >> testItemsHasContextMenu [
 
 	| menu |
@@ -46,7 +48,7 @@ IceTipWorkingCopyBrowserTest >> testItemsHasContextMenu [
 	self assert: menu isNotNil.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipWorkingCopyBrowserTest >> testPackageHasBrowseRepositoryVersionOption [
 
 	| menu |
@@ -55,7 +57,7 @@ IceTipWorkingCopyBrowserTest >> testPackageHasBrowseRepositoryVersionOption [
 	self assert: (menu defaultGroup menuItems anySatisfy: [ :e | e name = 'Browse this version in Monticello' ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 IceTipWorkingCopyBrowserTest >> testPackageIsShownInList [
 
 	self assert: (presenter packagesTable items anySatisfy: [ :each | each name = self packageName1 ])

--- a/Iceberg-UI-Tests/IceTipWorkingCopyBrowserWithRemoteTest.class.st
+++ b/Iceberg-UI-Tests/IceTipWorkingCopyBrowserWithRemoteTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #IceTipWorkingCopyBrowserWithRemoteTest,
-	#superclass : #IceTipWorkingCopyBrowserTest,
+	#name : 'IceTipWorkingCopyBrowserWithRemoteTest',
+	#superclass : 'IceTipWorkingCopyBrowserTest',
 	#instVars : [
 		'remoteWorkingCopy'
 	],
-	#category : #'Iceberg-UI-Tests-Browsers'
+	#category : 'Iceberg-UI-Tests-Browsers',
+	#package : 'Iceberg-UI-Tests',
+	#tag : 'Browsers'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 IceTipWorkingCopyBrowserWithRemoteTest >> newFixture [
 
 	^ IceClonedFromRemoteFixture inGit
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> setUp [
 
 	super setUp.
@@ -30,7 +32,7 @@ IceTipWorkingCopyBrowserWithRemoteTest >> setUp [
 	self remoteRepository push
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testAddPackageInModelThenAnnounceAddsPackageToList [
 
 	"Add package directly in the model without notifying the UI"
@@ -43,7 +45,7 @@ IceTipWorkingCopyBrowserWithRemoteTest >> testAddPackageInModelThenAnnounceAddsP
 	self assert: (presenter showsPackageNamed: self packageName2).
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testCommitThenAnnounceCommitedUpdatesPushBadge [
 
 	| pushButton |
@@ -60,7 +62,7 @@ IceTipWorkingCopyBrowserWithRemoteTest >> testCommitThenAnnounceCommitedUpdatesP
 	self assert: pushButton badge equals: '1'
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testCommitThenAnnounceUpdatesPushBadge [
 
 	| pushButton |
@@ -77,7 +79,7 @@ IceTipWorkingCopyBrowserWithRemoteTest >> testCommitThenAnnounceUpdatesPushBadge
 	self assert: pushButton badge equals: '1'
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testFetchButtonUpdatesPullBadge [
 
 	"If fetch brings commits in the upstream of the current branch, the badge of the pull button should be updated"	
@@ -90,7 +92,7 @@ IceTipWorkingCopyBrowserWithRemoteTest >> testFetchButtonUpdatesPullBadge [
 	self assert: pullButton badge equals: 1
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testMakePackageDirtyInModelThenAnnounceMakesPackageDirtyInList [
 
 	"Add package directly in the model without notifying the UI"
@@ -103,7 +105,7 @@ IceTipWorkingCopyBrowserWithRemoteTest >> testMakePackageDirtyInModelThenAnnounc
 	self assert: (presenter packagesTable valueAtColumn: 2 row: 1) equals: ('*', self packageName1).
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testMakePackageNonDirtyInModelThenAnnounceMakesPackageDirtyInList [
 
 	"Add package directly in the model without notifying the UI"
@@ -123,13 +125,13 @@ IceTipWorkingCopyBrowserWithRemoteTest >> testMakePackageNonDirtyInModelThenAnno
 	self assert: (presenter packagesTable valueAtColumn: 2 row: 1) equals: self packageName1.
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testNonDirtyPackageIsNotDirtyInList [
 
 	self assert: (presenter packagesTable valueAtColumn: 2 row: 1) equals: self packageName1.
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testPullButtonHasNoBadgeBeforeFetching [
 
 	"If we don't fetch, the badge of the pull button should not be updated"	
@@ -138,7 +140,7 @@ IceTipWorkingCopyBrowserWithRemoteTest >> testPullButtonHasNoBadgeBeforeFetching
 	self deny: pullButton hasBadge
 ]
 
-{ #category : #'tests-fetch' }
+{ #category : 'tests-fetch' }
 IceTipWorkingCopyBrowserWithRemoteTest >> testPushButtonHasNoBadgeBeforeCommit [
 
 	| pushButton |

--- a/Iceberg-UI-Tests/package.st
+++ b/Iceberg-UI-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Iceberg-UI-Tests' }
+Package { #name : 'Iceberg-UI-Tests' }


### PR DESCRIPTION
During the development of Pharo 12 we will bring some changes to tonel such as an improved way to deal with packages and tags and maybe a way to set the deprecated aliases of a class. 

This change make Iceberg depend on the branch Pharo12 of the tonel repository. 

This branch has one change ahead of the master branch that is the introduction of TonelWriterV3. This new writer will export the package and the tag of classes on top of the category.  It also update the reader to be able to read this new format and try to be as backward compatible as possible.