### PR TITLE
Make repair detached display the current branch

### DIFF
--- a/Iceberg-TipUI/IceTipExistingBranchPanel.class.st
+++ b/Iceberg-TipUI/IceTipExistingBranchPanel.class.st
@@ -56,16 +56,16 @@ IceTipExistingBranchPanel >> initializeBranchesList [
 
 	branchesList
 		hideColumnHeaders;
-		addColumn: (SpStringTableColumn evaluated: #shortDescription);
+		addColumn: (SpStringTableColumn evaluated: [: branch | self shortDescriptionFor: branch ]);
 		items: self model branchModels.
 
 	self model branchModels
 		detect: #isHead
 		ifFound: [ :head | branchesList selectItem: head ]
-		ifNone: [ self model hasBranches ifTrue: [ branchesList selectIndex: 1 ] ].
+		ifNone: [
+		self model hasBranches ifTrue: [ branchesList selectIndex: 1 ] ].
 
-	self flag: #pharoTodo. "Instead of detecting 'isHead', we would prefer to select 'self model defaultBranchSelection' but we have a bug with the caches. The reason is that #branchModels returns the same cache used by the list but not #defaultBranchSelection."
-
+	self flag: #pharoTodo "Instead of detecting 'isHead', we would prefer to select 'self model defaultBranchSelection' but we have a bug with the caches. The reason is that #branchModels returns the same cache used by the list but not #defaultBranchSelection."
 ]
 
 { #category : #initialization }
@@ -79,6 +79,12 @@ IceTipExistingBranchPanel >> initializePresenters [
 IceTipExistingBranchPanel >> selectedBranch [
 
 	^ self branchesList selection selectedItem
+]
+
+{ #category : #initialization }
+IceTipExistingBranchPanel >> shortDescriptionFor: aBranch [
+	aBranch isHead ifFalse: [ ^aBranch shortDescription  ].
+	^aBranch shortDescription , ' (current)'
 ]
 
 { #category : #initialization }

--- a/Iceberg-TipUI/IceTipMergeBranchDialog.class.st
+++ b/Iceberg-TipUI/IceTipMergeBranchDialog.class.st
@@ -35,22 +35,20 @@ IceTipMergeBranchDialog >> beSwitchAndMerge [
 IceTipMergeBranchDialog >> createMergeBranchTypes [
 
 	| allTypes |
-	"Collect types local+remotes"	
-	allTypes :=  { 
-	 	(IceTipMergeBranchPanel on: self model) 
-			titleForWindow: 'Local';
-			withoutHead;
-			icon: (self iconNamed: #branch);
-			yourself }, 
-	(self model remoteModels collect: [ :each | 
-		(IceTipMergeBranchPanel on: each)
-			titleForWindow: each name;
-			icon: (self iconNamed: #remote);
-			yourself ]).
-	
+	"Collect types local+remotes"
+	allTypes := { ((IceTipMergeBranchPanel on: self model)
+		             titleForWindow: 'Local';
+		             icon: (self iconNamed: #branch);
+		             yourself) }
+	            , (self model remoteModels collect: [ :each |
+			             (IceTipMergeBranchPanel on: each)
+				             titleForWindow: each name;
+				             icon: (self iconNamed: #remote);
+				             yourself ]).
+
 	"Doing this because I can trigger the accept inside the panels."
 	allTypes do: [ :each | each onAccept: [ self closeWindow ] ].
-	
+
 	^ allTypes
 ]
 


### PR DESCRIPTION
Allow repair detached by "merging" into the current branch on disk. We simply display the current branch and mark it and "current". This is useful for example after changing some resource file on disk.
This fixes issue listed in Pharo https://github.com/pharo-project/pharo/issues/6797