### PR TITLE
Fix misspellings of ‘committing’, ‘committed’ and ‘uncommitted’ in literal strings

### DIFF
--- a/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
@@ -58,7 +58,7 @@ IceGitHubNewPullRequestAction >> validateMakePullRequestOn: aRepository [
 
 	| status |
 	status := OrderedCollection new: 2.
-	aRepository isModified ifTrue: [ status add: 'Uncommited changes' ].
+	aRepository isModified ifTrue: [ status add: 'Uncommitted changes' ].
 	(aRepository outgoingCommitsTo: remote) ifNotEmpty: [ :commits |
 		'{1} not published' format: { commits size } ].
 	status ifEmpty: [ ^ true ].

--- a/Iceberg-Tests/IceGitMergeTest.class.st
+++ b/Iceberg-Tests/IceGitMergeTest.class.st
@@ -327,7 +327,7 @@ IceGitMergeTest >> testMergeWithMissingProjectFile [
 	fileRef := self repository location / 'test1.txt'.
 	fileRef writeStreamDo: [ :stream | stream << 'test1' ].
 	self repository index addPath: (fileRef relativeTo: self repository location).
-	self repository commitWithMessage: 'commiting something'.
+	self repository commitWithMessage: 'committing something'.
 	incomingBranch := self repository branch.
 	
 	self repository checkoutBranch: 'master'.	

--- a/Iceberg-TipUI/IceTipCommentPanel.class.st
+++ b/Iceberg-TipUI/IceTipCommentPanel.class.st
@@ -85,14 +85,14 @@ IceTipCommentPanel >> initializePresenters [
 		add: (self newToolbarToggleButton
 			icon: (self application iconNamed: #smallSave);
 			label: 'Save image';
-			help: 'Save image when commiting';
+			help: 'Save image when committing';
 			state: self isSaving;
 			whenChangedDo: [ :aBoolean | self saveOnCommit: aBoolean ];
 			yourself);
 		add: (self newToolbarToggleButton
 			icon: (self application iconNamed: #smallError);
 			label: 'Run critics';
-			help: 'Run critics when commiting';
+			help: 'Run critics when committing';
 			state: self isRunningCriticsOnCommit;
 			whenChangedDo: [ :aBoolean | self runCriticsOnCommit: aBoolean ];
 			yourself);
@@ -113,7 +113,7 @@ IceTipCommentPanel >> initializePresenters [
 		placeholder: 'A comment for your commit';
 		yourself.
 
-	fixesHelpString := 'Enter the number of the issue that you fixed. Github will close it when it will be commited or merged in the default branch'.
+	fixesHelpString := 'Enter the number of the issue that you fixed. Github will close it when it will be committed or merged in the default branch'.
 	fixesLabel := self newLabel
 		label: 'Fixes #';
 		help: fixesHelpString;

--- a/Iceberg-TipUI/IceTipCommitAction.class.st
+++ b/Iceberg-TipUI/IceTipCommitAction.class.st
@@ -16,7 +16,7 @@ Class {
 IceTipCommitAction >> basicExecute [
 	self validateCanCommit.
 	UIManager default
-		informUser: 'Commiting...' 
+		informUser: 'Committing...' 
 		during: [ 
 			self repository
 				commitChanges: (diff copyWithOnly: items)

--- a/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
+++ b/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
@@ -228,7 +228,7 @@ IceTipInteractiveErrorVisitor >> visitShouldCommitBeforePullError: anError [
 	| continue |
 	continue := context application newConfirm
 		            label: 
-			            'Your repository has uncommited changes. Merging incoming commits will change
+			            'Your repository has uncommitted changes. Merging incoming commits will change
 your current working copy and your current state will not be recoverable. 
 We recommend that you commit first and then pull incoming changes again.';
 		            title: 'You might loose your current changes!';

--- a/Iceberg-TipUI/IceTipPackageModel.class.st
+++ b/Iceberg-TipUI/IceTipPackageModel.class.st
@@ -114,7 +114,7 @@ IceTipPackageModel >> status [
 	[
 		self entity repository isMissing ifTrue: [ ^ 'Local repository missing' ].
 		self entity isLoaded ifFalse: [ ^ 'Not loaded' ].
-		self entity isModified ifTrue: [ ^ 'Uncommited changes' ].
+		self entity isModified ifTrue: [ ^ 'Uncommitted changes' ].
 		^ 'Up to date' ] 
 	on: Error do: [ :e | 
 		^ e description ]

--- a/Iceberg-TipUI/IceTipRepairCheckoutBranch.class.st
+++ b/Iceberg-TipUI/IceTipRepairCheckoutBranch.class.st
@@ -20,7 +20,7 @@ This situation happens because the code loaded in your image does not correspond
 
 This action opens a preview window before doing any change.
 
-This operation will modify the state of your working copy on disk. All non-commited changes in your disk working copy that are not in the image will be lost (this can happen if you edited the repository from outside). If you want to keep them, perform a commit from outside before.'
+This operation will modify the state of your working copy on disk. All non-committed changes in your disk working copy that are not in the image will be lost (this can happen if you edited the repository from outside). If you want to keep them, perform a commit from outside before.'
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipRepairCheckoutNewBranch.class.st
+++ b/Iceberg-TipUI/IceTipRepairCheckoutNewBranch.class.st
@@ -19,7 +19,7 @@ This will not lose any change in the image.
 
 This situation happens because the code loaded in your image does not correspond with the status of your repository.
 
-This operation will modify the state of your working copy on disk. All non-commited changes in your disk working copy that are not in the image will be lost (this can happen if you edited the repository from outside). If you want to keep them, perform a commit from outside before.'
+This operation will modify the state of your working copy on disk. All non-committed changes in your disk working copy that are not in the image will be lost (this can happen if you edited the repository from outside). If you want to keep them, perform a commit from outside before.'
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipRepairCreateSubdirectory.class.st
+++ b/Iceberg-TipUI/IceTipRepairCreateSubdirectory.class.st
@@ -15,9 +15,9 @@ IceTipRepairCreateSubdirectory class >> help [
 	^ 'Create a new subdirectory for the code. 
 
 The configured source directory does not exist in the repository. 
-It is possible that the directory has been deleted or never commited after creating the meta-data.
+It is possible that the directory has been deleted or never committed after creating the meta-data.
 
-This operation will modify the state of your working copy on disk. All non-commited changes in your disk working copy that are not in the image will be lost (this can happen if you edited the repository from outside). If you want to keep them, perform a commit from outside before.'
+This operation will modify the state of your working copy on disk. All non-committed changes in your disk working copy that are not in the image will be lost (this can happen if you edited the repository from outside). If you want to keep them, perform a commit from outside before.'
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipRepairDiscardAndLoad.class.st
+++ b/Iceberg-TipUI/IceTipRepairDiscardAndLoad.class.st
@@ -17,7 +17,7 @@ IceTipRepairDiscardAndLoad class >> help [
 
 This action will synchronize your image with the code in the repository.
 
-All the changes in the image that have not been commited will be lost.
+All the changes in the image that have not been committed will be lost.
 
 This situation happens because loaded code in your image is from a different commit than the current commit (HEAD) in the repository.
 

--- a/Iceberg-TipUI/IceTipRepairMergeWithBranch.class.st
+++ b/Iceberg-TipUI/IceTipRepairMergeWithBranch.class.st
@@ -18,7 +18,7 @@ This will not lose any change in the image but may lead to conflicts. If there a
 
 This situation happens because loaded code in your image is from a different commit than the current commit (HEAD) in the repository.
 
-This operation will modify the state of your working copy in disk, the checkouted branch will replace the disk working copy. All non-commited changes in your disk working copy will be lost. If you want to keep them, perform a commit from outside before.'
+This operation will modify the state of your working copy in disk, the checkouted branch will replace the disk working copy. All non-committed changes in your disk working copy will be lost. If you want to keep them, perform a commit from outside before.'
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipRepairPullRemoteBranch.class.st
+++ b/Iceberg-TipUI/IceTipRepairPullRemoteBranch.class.st
@@ -17,7 +17,7 @@ This will not lose any change in the image.
 
 This situation happens because the code loaded in your image is not in the branch currently selected on your repository.
 
-This operation will modify the state of your working copy in disk. All non-commited changes in your disk working copy that are not in the image will be lost. If you want to keep them, perform a commit from outside before.'
+This operation will modify the state of your working copy in disk. All non-committed changes in your disk working copy that are not in the image will be lost. If you want to keep them, perform a commit from outside before.'
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipRepositoryModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryModel.class.st
@@ -450,7 +450,7 @@ IceTipRepositoryModel >> status [
 		self isLoaded ifFalse: [ ^ 'Not loaded' ].
 
 		status := OrderedCollection new.
-		entity isModified ifTrue: [ status add: 'Uncommited changes' ].
+		entity isModified ifTrue: [ status add: 'Uncommitted changes' ].
 		
 		incoming := self incomingCommits size.
 		incoming > 0 ifTrue: [ status add: ('{1} incoming' format: { incoming })].
@@ -510,7 +510,7 @@ IceTipRepositoryModel >> statusString [
 		self isLoaded ifFalse: [ ^ 'Not loaded' ].
 
 		status := OrderedCollection new.
-		entity isModified ifTrue: [ status add: 'Uncommited changes' ].
+		entity isModified ifTrue: [ status add: 'Uncommitted changes' ].
 		
 		incoming := self incomingCommits size.
 		incoming > 0 ifTrue: [ status add: ('{1} incoming' format: { incoming })].

--- a/Iceberg/IceTipCommitSettings.class.st
+++ b/Iceberg/IceTipCommitSettings.class.st
@@ -80,21 +80,21 @@ IceTipCommitSettings class >> settingsOn: aBuilder [
 				noOrdering;
 				target: self;
 				default: self critiquesOnCommitDefaultValue;
-				label: 'Run Code Critiques when commiting';
+				label: 'Run Code Critiques when committing';
 				description:
 					'Check if you want to run the code critiques on the changes each time you commit them'.
 			(aBuilder setting: #saveImageOnCommit)
 				noOrdering;
 				target: self;
 				default: self saveImageOnCommitDefaultValue;
-				label: 'Save the image when commiting';
+				label: 'Save the image when committing';
 				description:
 					'Check if you want to save the image each time you commit something'.
 			(aBuilder setting: #pushOnCommit)
 				noOrdering;
 				target: self;
 				default: self pushOnCommitDefaultValue;
-				label: 'Push when commiting';
+				label: 'Push when committing';
 				description:
 					'Check if you want to push your changes each time you commit something' ]
 ]


### PR DESCRIPTION
This pull request fixes misspellings, in literal strings, of words derived from [‘commit’](https://en.wiktionary.org/wiki/commit):

* commiting → [committing](https://en.wiktionary.org/wiki/committing)
* [commited](https://en.wiktionary.org/wiki/commited) → [committed](https://en.wiktionary.org/wiki/committed)
* uncommited → [uncommitted](https://en.wiktionary.org/wiki/uncommitted)
