### PR TITLE
Avoid useless garbage collects

### DIFF
--- a/Iceberg-Tests/IceGitTestFactory.class.st
+++ b/Iceberg-Tests/IceGitTestFactory.class.st
@@ -109,6 +109,10 @@ IceGitTestFactory >> tearDownWithRepository: aRepository [
 
 	aRepository ifNotNil: [
 		aRepository free.
-		aRepository location ifNotNil: #ensureDeleteAll ].
+		[ aRepository location ifNotNil: #ensureDeleteAll ]
+			on: CannotDeleteFileException
+			do: [ "On windows it is possible we need to finalize everything before deleting the files. We do not do it directly to avoid to lose too much speed"
+				Smalltalk garbageCollect.
+				aRepository location ifNotNil: #ensureDeleteAll ] ].
 	self remoteFileUrl asFileReference ensureDeleteAll
 ]

--- a/Iceberg-Tests/IceGitTestFactory.class.st
+++ b/Iceberg-Tests/IceGitTestFactory.class.st
@@ -106,10 +106,9 @@ IceGitTestFactory >> remoteFileUrl [
 
 { #category : 'initialization' }
 IceGitTestFactory >> tearDownWithRepository: aRepository [
-		
+
 	aRepository ifNotNil: [
 		aRepository free.
-		Smalltalk garbageCollect.
 		aRepository location ifNotNil: #ensureDeleteAll ].
 	self remoteFileUrl asFileReference ensureDeleteAll
 ]

--- a/Iceberg-Tests/IceNotYetClonedRepositoryFixture.class.st
+++ b/Iceberg-Tests/IceNotYetClonedRepositoryFixture.class.st
@@ -110,5 +110,9 @@ IceNotYetClonedRepositoryFixture >> setUp [
 { #category : 'running' }
 IceNotYetClonedRepositoryFixture >> tearDown [
 
-	self location ifNotNil: #ensureDeleteAll
+	[ self location ifNotNil: #ensureDeleteAll ]
+		on: CannotDeleteFileException
+		do: [ "On windows it is possible we need to finalize everything before deleting the files. We do not do it directly to avoid to lose too much speed"
+			Smalltalk garbageCollect.
+			self location ifNotNil: #ensureDeleteAll ]
 ]

--- a/Iceberg-Tests/IceNotYetClonedRepositoryFixture.class.st
+++ b/Iceberg-Tests/IceNotYetClonedRepositoryFixture.class.st
@@ -110,6 +110,5 @@ IceNotYetClonedRepositoryFixture >> setUp [
 { #category : 'running' }
 IceNotYetClonedRepositoryFixture >> tearDown [
 
-	Smalltalk garbageCollect.
-	self location ifNotNil: #ensureDeleteAll.
+	self location ifNotNil: #ensureDeleteAll
 ]


### PR DESCRIPTION
Some garbage collects seems useless in Iceberg tests (I ran the tests multiple times without troubles) and are slowing down Iceberg tests