### PR TITLE
Remove only the reverted diff entry rather than recompute the whole diff after revert (fixes #1745)

### DIFF
--- a/Iceberg-TipUI/IceTipDiffPanel.class.st
+++ b/Iceberg-TipUI/IceTipDiffPanel.class.st
@@ -84,6 +84,29 @@ IceTipDiffPanel >> diffContentsLeft: leftString right: rightString [
 		rightText: rightString
 ]
 
+{ #category : 'initialization' }
+IceTipDiffPanel >> diffEntryRemoved: announcement [
+
+	| parent |
+	(parent := announcement entry parent) removeChild: announcement entry.
+	"Removing all changes to a class should remove the class node too,
+	unless the class definition has changed as well. Extension definitions
+	may appear as an 'addition' or 'removal', but can only exist when methods
+	of that class have changed. Repeat this process to check if the containing
+	package no longer has any changes. Cannot remove the root node as it has
+	no parent, but it's fine to just leave it there empty--though perhaps we should
+	close the browser instead in that case?"
+	[
+	parent parent notNil and: [
+		parent isEmpty and: [
+			parent value isNoModification or: [
+				parent value definition isExtensionDefinition ] ] ] ] whileTrue: [
+		parent parent removeChild: parent.
+		parent := parent parent ].
+
+	self basicRefresh
+]
+
 { #category : 'accessing - ui' }
 IceTipDiffPanel >> diffPanel [
 
@@ -224,10 +247,9 @@ IceTipDiffPanel >> setModelBeforeInitialization: anObject [
 IceTipDiffPanel >> subscribeToAnnouncements [
 
 	self announcer
-		when: IceTipDiffEntryRemoved 
-		send: #refresh
+		when: IceTipDiffEntryRemoved
+		send: #diffEntryRemoved:
 		to: self
-
 ]
 
 { #category : 'specs' }


### PR DESCRIPTION
This feels pretty brittle and like the model objects should be able to do more of the work—for instance, the fact that I have to separately check `isNoModification or: [isExtensionDefinition]`, because extension class definitions are always "added", yet have no content of their own, where a packaged class definition could be added as just an empty class. Also little things like the tree entries not having a "remove" API so I have to traverse up and ask the parent to remove the child, etc. Feels like the API here is under-developed, basically—and that makes sense because we ultimately could do things like update the diff in-place when a method is saved (after all, the only thing that can possibly change is the diff entry for that method...), which would probably drive the creation of a richer API here.

So—if this seems like a step forward, great. If you have any suggestions for making it less ugly and brittle without tackling a major revamp of the diff panel, I'm happy to put in a little more work.