### PR TITLE
Implement IceWorkingCopyPatcherVisitor>>visitExtensionDefinition:

### DIFF
--- a/Iceberg/IceWorkingCopyPatcherVisitor.class.st
+++ b/Iceberg/IceWorkingCopyPatcherVisitor.class.st
@@ -90,6 +90,13 @@ IceWorkingCopyPatcherVisitor >> visitDirectoryDefinition: anIceDirectoryDefiniti
 ]
 
 { #category : 'visiting' }
+IceWorkingCopyPatcherVisitor >> visitExtensionDefinition: anIceExtensionDefinition [
+	"An extension definition represents no changes on its own, visit the individual extension-method changes."
+
+	self visitChildrenOf: currentNode
+]
+
+{ #category : 'visiting' }
 IceWorkingCopyPatcherVisitor >> visitFileNode: anIceFileDefinition [
 	
 	"Ignore files, they are not loaded in the image"


### PR DESCRIPTION
Fixes error trying to revert all extension-method changes in a class, i.e. right-click on the class extension "definition" node and choose revert. Extension definitions are just a container and have no content of their own, so the same implementation as #visitDirectoryDefinition:--just visit the children--seems reasonable.

This fixes [pharo-project/pharo#14395](https://github.com/pharo-project/pharo/issues/14395)—when I reported it I didn't realize Iceberg had its own repo...