### PR TITLE
Add $i meta as shortcut to inspect a repo

### DIFF
--- a/Iceberg-TipUI/IceTipInspectCommand.class.st
+++ b/Iceberg-TipUI/IceTipInspectCommand.class.st
@@ -48,3 +48,9 @@ IceTipInspectCommand >> item [
 	^ (maybeCachedObject respondsTo: #realObject)
 		ifTrue: [ maybeCachedObject realObject ] ifFalse: [ maybeCachedObject ]
 ]
+
+{ #category : 'activation' }
+IceTipBrowseCommand >> shortcutKey [
+
+	^ $i meta
+]


### PR DESCRIPTION
This is a shortcut for Right click -> Extras -> Inspect.

To test, open Iceberg repositories window, select a repo and press cmd+i (MacOS)
