### PR TITLE
Remove dependency to Gofer

### DIFF
--- a/Iceberg/IceMetacelloRepositoryAdapter.class.st
+++ b/Iceberg/IceMetacelloRepositoryAdapter.class.st
@@ -79,23 +79,6 @@ IceMetacelloRepositoryAdapter >> getOrCreateIcebergRepository [
 	^ self repository
 ]
 
-{ #category : 'accessing' }
-IceMetacelloRepositoryAdapter >> goferPriority [
-	^ 8
-]
-
-{ #category : 'accessing' }
-IceMetacelloRepositoryAdapter >> goferReferences [
-	
-	self repository head description = projectVersion ifFalse: [ (self repository commitishNamed: projectVersion) checkoutWithStrategy: IceCheckoutDoNotLoadPackages new ].
-	
-	^ self repository workingCopy packages 
-		collect: [ :package | 
-			GoferResolvedReference 
-				name: package latestVersion info name 
-				repository: self ]
-]
-
 { #category : 'testing' }
 IceMetacelloRepositoryAdapter >> hasNoLoadConflicts: anMCGitBasedRepository [
 	"Copied from MCGitBasedNetworkRepository"


### PR DESCRIPTION
This PR removes the dependency to gofer now that Metacello does not depend on gofer anymore.