### PR TITLE
Ci issues

### DIFF
--- a/Iceberg-Libgit/TIceRepositoryReader.trait.st
+++ b/Iceberg-Libgit/TIceRepositoryReader.trait.st
@@ -8,11 +8,6 @@ Trait {
 	#tag : 'Writing'
 }
 
-{ #category : 'accessing' }
-TIceRepositoryReader classSide >> id [
-	^ self required
-]
-
 { #category : 'testing' }
 TIceRepositoryReader classSide >> isLegacyDefault [
 	^ false

--- a/Iceberg-Libgit/TIceRepositoryWriter.trait.st
+++ b/Iceberg-Libgit/TIceRepositoryWriter.trait.st
@@ -8,11 +8,6 @@ Trait {
 	#tag : 'Writing'
 }
 
-{ #category : 'accessing' }
-TIceRepositoryWriter classSide >> id [
-	^ self required
-]
-
 { #category : 'testing' }
 TIceRepositoryWriter classSide >> isDefault [
 	"Indicates when this is default when create new repositories"

--- a/Iceberg-TipUI/IceTipInspectCommand.class.st
+++ b/Iceberg-TipUI/IceTipInspectCommand.class.st
@@ -48,9 +48,3 @@ IceTipInspectCommand >> item [
 	^ (maybeCachedObject respondsTo: #realObject)
 		ifTrue: [ maybeCachedObject realObject ] ifFalse: [ maybeCachedObject ]
 ]
-
-{ #category : 'activation' }
-IceTipBrowseCommand >> shortcutKey [
-
-	^ $i meta
-]

--- a/Iceberg-TipUI/IceTipInspectCommand.class.st
+++ b/Iceberg-TipUI/IceTipInspectCommand.class.st
@@ -38,13 +38,3 @@ IceTipInspectCommand >> iconName [
 
 	^ #glamorousInspect
 ]
-
-{ #category : 'accessing' }
-IceTipInspectCommand >> item [
-
-	| maybeCachedObject |
-	maybeCachedObject := super item.
-	
-	^ (maybeCachedObject respondsTo: #realObject)
-		ifTrue: [ maybeCachedObject realObject ] ifFalse: [ maybeCachedObject ]
-]

--- a/Iceberg-TipUI/IceTipPackageModel.class.st
+++ b/Iceberg-TipUI/IceTipPackageModel.class.st
@@ -12,7 +12,7 @@ Class {
 	#tag : 'Model'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'instance creation' }
 IceTipPackageModel class >> workingCopyModel: aWorkingCopyModel on: aPackage [
 
 	^ (self


### PR DESCRIPTION
This PR address two current errors reported by the Pharo CI: 

- First one is a simple uncategorized method
- Second one is an unused method in a trait.

```
ProperMethodCategorizationTest
 ✗ #testNoUncategorizedMethods (15ms)
TestFailure: the following classes have uncategorized methods: an OrderedCollection(IceTipPackageModel class)
ProperMethodCategorizationTest(TestAsserter)>>assert:description:resumable:
ProperMethodCategorizationTest(TestAsserter)>>assert:description:
ProperMethodCategorizationTest>>testNoUncategorizedMethods ...assert: remaining isEmpty description: 'the following classes have uncategorized methods: ' , remaining asString
ProperMethodCategorizationTest(TestCase)>>performTest

ReleaseTest
 ✗ #testThatThereAreNoSelectorsRemain...tAreSentButNotImplemented (658ms)
TestFailure: an OrderedCollection('DeprecationTest>>#testTransformingDeprecation' 'IceTipCherryPickCommand>>#selectedCommitish' 'IceTipInspectCommand>>#item' 'TIceRepositoryReader classTrait>>#id' 'TIceRepositoryWriter classTrait>>#id') should have been empty
ReleaseTest(TestAsserter)>>assert:description:resumable:
ReleaseTest(TestAsserter)>>assert:description:
ReleaseTest(TestAsserter)>>assertEmpty:
ReleaseTest>>testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented ...assertEmpty: (violations difference: knownFailures)
ReleaseTest(TestCase)>>performTest
```

The problem with the unused method `id` is the `required` message, which is not implemeted.

The only user is `IceRepositoryProperties>>readerClass`. This method sends `users` as follows:

```smalltalk
readerClass
	^ TIceRepositoryReader users detect: [ :each | each id = self fileFormat id  ]
```
so the users could be:

- IceLibgitTonelReader
- IceLibgitFiletreeReader

which have their own implementation of `id`, answering #tonel or #filetree

The `required` method was implemented in `MetacelloMCVersionSpecLoader` as:

```smalltalk
required

	required == nil ifTrue: [ ^#() ].
	^ required
```

but it is not present anymore.