### PR TITLE
Allow to set tonel writer version to use for export

### DIFF
--- a/Iceberg-Libgit-Tonel/IceLibgitTonelWriter.class.st
+++ b/Iceberg-Libgit-Tonel/IceLibgitTonelWriter.class.st
@@ -37,9 +37,10 @@ IceLibgitTonelWriter class >> forInternalStore [
 
 { #category : 'writing' }
 IceLibgitTonelWriter class >> forInternalStoreFileOut: aMCVersion on: aRepository [
-	self forInternalStore 
-		fileOut: aMCVersion
-		on: aRepository subdirectoryReference
+
+	(self forInternalStore forVersion: (aRepository properties tonelVersion ifNil: [ self forInternalStore defaultVersion ])) new
+		directoryReference: aRepository subdirectoryReference;
+		writeVersion: aMCVersion
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-Libgit/IceRepositoryProperties.class.st
+++ b/Iceberg-Libgit/IceRepositoryProperties.class.st
@@ -50,9 +50,8 @@ IceRepositoryProperties class >> propertiesFileName [
 
 { #category : 'instance creation' }
 IceRepositoryProperties class >> readPropertiesFrom: aFileReference [
-	self flag: #pharoFixMe.	"When Pharo 6.1 will not be supported anymore we can directly use: `ref readStreamDo: [ :stream | STON fromStream: stream ]` but currently FileReference>>readStream return a ZnBufferedStream in Pharo 61 and a ZnCharacterReadStream decoding utf8 in Pharo 7."
-	^ aFileReference
-		binaryReadStreamDo: [ :stream | STON fromStream: (ZnCharacterReadStream on: stream encoding: 'utf8') ]
+
+	^ aFileReference readStreamDo: [ :stream | STON fromStream: stream ]
 ]
 
 { #category : 'comparing' }

--- a/Iceberg-Libgit/IceRepositoryProperties.class.st
+++ b/Iceberg-Libgit/IceRepositoryProperties.class.st
@@ -210,6 +210,12 @@ IceRepositoryProperties >> storeOnFileReference: aFileReference [
 				nextPut: self properties  ]
 ]
 
+{ #category : 'private' }
+IceRepositoryProperties >> tonelVersion [
+
+	^ self properties at: #version ifAbsent: [ nil ]
+]
+
 { #category : 'accessing' }
 IceRepositoryProperties >> writerClass [
 	^ self properties


### PR DESCRIPTION
This change allows one to set the tonel writer version to use for a project in the .properties file of a project.

For project available on P11 and P12, to avoid to rewrite all the file each time we commit on a different version of Pharo we can provide those properties:

```
{
	#format : #tonel,
	#version: #'1.0'
}
```

And the v1 format will be used on both versions of Pharo. 

If it does not find the version provided, it will fallback to the default version of the image.