### PR TITLE
Fix misspellings of `committing`, `committed` and `uncommitted`

### DIFF
--- a/Iceberg-Libgit/IceGitIndex.class.st
+++ b/Iceberg-Libgit/IceGitIndex.class.st
@@ -30,7 +30,7 @@ IceGitIndex >> addToGitIndex [
 	repository addFilesToIndex: modifiedFilePaths.
 ]
 
-{ #category : 'API - commiting' }
+{ #category : 'API - committing' }
 IceGitIndex >> commitWithMessage: message andParents: parentCommits [
 	
 	| index |
@@ -81,7 +81,7 @@ IceGitIndex >> isEmpty [
 	^ modifiedFilePaths isEmpty
 ]
 
-{ #category : 'API - commiting' }
+{ #category : 'API - committing' }
 IceGitIndex >> libGitCommitsFrom: aLGitRepository for: aListOfCommitish [
 	^ aListOfCommitish collect: 
 		[ :commitish | 

--- a/Iceberg-Memory/IceMemoryIndex.class.st
+++ b/Iceberg-Memory/IceMemoryIndex.class.st
@@ -22,7 +22,7 @@ IceMemoryIndex >> addPackage: anIcePackageDefinition [
 	"Nothing, the package should be already added"
 ]
 
-{ #category : 'API-commiting' }
+{ #category : 'API - committing' }
 IceMemoryIndex >> commitWithMessage: message andParents: parentCommits [
 
 	| newCommit versionInfos packageNames iceCommit head headCommit |

--- a/Iceberg-Tests/IceDirtyDetachedWorkingCopyTest.class.st
+++ b/Iceberg-Tests/IceDirtyDetachedWorkingCopyTest.class.st
@@ -21,7 +21,7 @@ IceDirtyDetachedWorkingCopyTest >> testIsDetached [
 { #category : 'tests' }
 IceDirtyDetachedWorkingCopyTest >> testPackageIsDirty [
 
-	"There are uncommited changes"
+	"There are uncommitted changes"
 	self assert: self repository workingCopy isModified
 ]
 

--- a/Iceberg-TipUI/IceCreateBranchCommand.class.st
+++ b/Iceberg-TipUI/IceCreateBranchCommand.class.st
@@ -1,6 +1,6 @@
 "
 I'm a command to create a new branch from a commit. 
-this is usefull in the case of commiting changes in unsync repositories (so you open a branch and you commit there)
+this is usefull in the case of committing changes in unsync repositories (so you open a branch and you commit there)
 "
 Class {
 	#name : 'IceCreateBranchCommand',

--- a/Iceberg-TipUI/IceTipCommitAction.class.st
+++ b/Iceberg-TipUI/IceTipCommitAction.class.st
@@ -65,7 +65,7 @@ IceTipCommitAction >> validateCanCommit [
 
 { #category : 'validating' }
 IceTipCommitAction >> validateChangeListNotEmpty [
-	"If there are no selected changed, no point on commiting :)"
+	"If there are no selected changed, no point on committing :)"
 	
 	items ifEmpty: [ IceNothingToCommit signal ]
 ]

--- a/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
+++ b/Iceberg-UI-Tests/IceTipCommitBrowserTest.class.st
@@ -119,7 +119,7 @@ IceTipCommitBrowserTest >> testIsAutomaticallySavingWhenChecked [
 ]
 
 { #category : 'tests' }
-IceTipCommitBrowserTest >> testIsCommitingCheckedItems [
+IceTipCommitBrowserTest >> testIsCommittingCheckedItems [
 	| diffTree |
 
 	presenter doCommit.
@@ -144,7 +144,7 @@ IceTipCommitBrowserTest >> testIsCommitingCheckedItems [
 ]
 
 { #category : 'tests' }
-IceTipCommitBrowserTest >> testIsCommitingWithTheRightMessage [
+IceTipCommitBrowserTest >> testIsCommittingWithTheRightMessage [
 	presenter doCommit.
 	self
 		assert: self repository branch commit comment
@@ -164,7 +164,7 @@ IceTipCommitBrowserTest >> testIsNotAutomaticallySavingWhenNotChecked [
 ]
 
 { #category : 'tests' }
-IceTipCommitBrowserTest >> testIsNotCommitingUncheckedItems [
+IceTipCommitBrowserTest >> testIsNotCommittingUncheckedItems [
 	| diffTree |
 	presenter diffPanel selectedItems
 		remove:

--- a/Iceberg/IceCommited.class.st
+++ b/Iceberg/IceCommited.class.st
@@ -1,5 +1,5 @@
 "
-Announces when a repository has commited.
+Announces when a repository has committed.
 "
 Class {
 	#name : 'IceCommited',

--- a/Iceberg/IceIndex.class.st
+++ b/Iceberg/IceIndex.class.st
@@ -30,7 +30,7 @@ IceIndex >> addPackage: aPackage [
 	self subclassResponsibility
 ]
 
-{ #category : 'API - commiting' }
+{ #category : 'API - committing' }
 IceIndex >> commitWithMessage: message andParents: parentCommits [
 
 	self subclassResponsibility.	

--- a/Iceberg/IcePackage.class.st
+++ b/Iceberg/IcePackage.class.st
@@ -1,7 +1,7 @@
 "
 Can give information about a package that is saved in a repository, for example: 
 - isLoaded if the package has been loaded into the image.
-- isModified if the package has local changes to be commited
+- isModified if the package has local changes to be committed
 - incomingCommits information about commits in the repository that are newer than the version loaded into the image.
 
 "

--- a/Iceberg/IceRemoteDesynchronized.class.st
+++ b/Iceberg/IceRemoteDesynchronized.class.st
@@ -1,6 +1,6 @@
 "
 I indicate when a remote is desyncronized. 
-It means the version I have in the working copy (not the image) is different to the version I have in the remote (then I need to pull/branch/whatever before commiting).
+It means the version I have in the working copy (not the image) is different to the version I have in the remote (then I need to pull/branch/whatever before committing).
 "
 Class {
 	#name : 'IceRemoteDesynchronized',

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,7 +4,7 @@
 ***Q.** The Image seems to freeze when doing a clone of a repository.*  
 **A.** This is because the operation is taking time and Iceberg still does not show feedback properly. You just need to be patient :)  
 
-***Q.** The Image freezes when cloning/commiting and there is nothing I can do to fix it. I used HTTPS as the protocol when doing the clone.*  
+***Q.** The Image freezes when cloning/committing and there is nothing I can do to fix it. I used HTTPS as the protocol when doing the clone.*  
 **A.** There is a known bug around HTTPS and getting the credentials. We will fix this, but while waiting for the fix, you can work around the problem by:  
 - Adding your credentials **before** doing any operation (go to `System Settings/Tools/Software Configuration Management/Iceberg/Plain credentials`)
 - Just using the SSH protocol instead (but that option is not as easy on Windows).  

--- a/docs/How-to-help-us,-What-you-could-contribute.md
+++ b/docs/How-to-help-us,-What-you-could-contribute.md
@@ -1,6 +1,6 @@
 There are many places where Iceberg can be improved. Some are due to missing knowledge, others from lack of resources (it goes without saying that all help is greatly appreciated). Apart from fixing issue and perfroming reviews, this page explains several standalone sub-projects where people could usefully help to improve Iceberg's general quality, in a smaller space.
 
-# Support Exporting without commiting
+# Support Exporting without committing
 
 There is no UI support for this, but it is doable from the backend although not correctly exposed.
 

--- a/docs/Iceberg-glossary.md
+++ b/docs/Iceberg-glossary.md
@@ -10,7 +10,7 @@ Iceberg also includes an object called the [working copy](The-Working-Copy(ies).
 Iceberg's working copy represents the code loaded in the image, with the loaded commit and the packages.
 
 #### The git index
-The index is an intermediate structure which is used to select the contents that are going to be commited. 
+The index is an intermediate structure which is used to select the contents that are going to be committed. 
 
 So, to commit changes to your local repository, two actions are needed: 
 1. `git add someFileOrDirectory` will add `someFileOrDirectory` to the index. 


### PR DESCRIPTION
An exhaustive version of #1754 applied to the entire project, excluding class names.