### PR TITLE
Default format

### DIFF
--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -83,7 +83,7 @@ IceTipEditProjectDialogPresenter >> connectPresenters [
 	self formatList
 		items: self formats;
 		display: [ :each | each description ];
-		selectItem: model repositoryProperties fileFormat.
+		selectItem: (self guessFormatFromDirectory: model sourceDirectoryReference).
 
 	self expandAndSelect: (RelativePath with: model sourceDirectory).
 
@@ -181,6 +181,8 @@ IceTipEditProjectDialogPresenter >> guessFormatFromDirectory: aFileReference [
 	"We take as guinea pig a sub-directory to guess what format it is on.
 	In case the current directory has no children directories, we just select the default format"
 	| guineaPig |
+	aFileReference exists ifFalse: [ ^ defaultFormat ].
+	
 	guineaPig := aFileReference children detect: [ :any | any isDirectory ] ifNone: [ ^ defaultFormat ].
 	
 	"Filetree must have precedence as it has the most restrictive name convention (directories ending with .package)"


### PR DESCRIPTION
Fixes https://github.com/pharo-vcs/iceberg/issues/1802

Set the default format in the format list in the edit project dialog when open.
Otherwise this is only set when selection changes.

<img width="468" alt="imagen" src="https://github.com/pharo-vcs/iceberg/assets/708322/48b37cb8-1b69-4b85-96f6-eb00da106b96">

Should this PR go against `dev-2.0` or `Pharo12`.
It seems `Pharo12` is ahead by several commits.