### PR TITLE
Refactor IceTipTreeNode to support use of a FormSet

### DIFF
--- a/Iceberg-TipUI/IceTipRepositoryModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryModel.class.st
@@ -397,7 +397,7 @@ IceTipRepositoryModel >> repositoryModelsByGroup [
 	^ {
 		  ((IceTipTreeRepositoryGroup on: self)
 			   name: 'Branches';
-			   icon: (self iconNamed: #branch);
+			   iconFormSet: (self iconFormSetNamed: #branch);
 			   children: (branches
 					    select: [ :each | each entity isLocal ]
 					    thenCollect: [ :each | IceTipTreeBranch on: each ]);
@@ -405,7 +405,7 @@ IceTipRepositoryModel >> repositoryModelsByGroup [
 		  "Remotes group"
 		  ((IceTipTreeRepositoryGroup on: self)
 			   name: 'Remotes';
-			   icon: (self iconNamed: #remote);
+			   iconFormSet: (self iconFormSetNamed: #remote);
 			   children: (self entity remotes collect: [ :eachRemote |
 						    | remoteModel |
 						    remoteModel := IceTipRemoteModel
@@ -423,7 +423,7 @@ IceTipRepositoryModel >> repositoryModelsByGroup [
 		  "Tags group"
 		  ((IceTipTreeRepositoryGroup on: self)
 			   name: 'Tags';
-			   icon: (self iconNamed: #glamorousBookmark);
+			   iconFormSet: (self iconFormSetNamed: #glamorousBookmark);
 			   children: (tags collect: [ :each | IceTipTreeTag on: each ]);
 			   yourself) }
 	"Branches group"

--- a/Iceberg-TipUI/IceTipTreeNode.class.st
+++ b/Iceberg-TipUI/IceTipTreeNode.class.st
@@ -52,11 +52,6 @@ IceTipTreeNode >> icon [
 ]
 
 { #category : 'accessing' }
-IceTipTreeNode >> icon: aForm [
-	self iconFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
-]
-
-{ #category : 'accessing' }
 IceTipTreeNode >> iconFormSet [
 	^ iconFormSet
 ]

--- a/Iceberg-TipUI/IceTipTreeNode.class.st
+++ b/Iceberg-TipUI/IceTipTreeNode.class.st
@@ -10,7 +10,7 @@ Class {
 	#instVars : [
 		'model',
 		'parent',
-		'icon'
+		'iconFormSet'
 	],
 	#category : 'Iceberg-TipUI-View-Repository',
 	#package : 'Iceberg-TipUI',
@@ -48,12 +48,22 @@ IceTipTreeNode >> doesNotUnderstand: aMessage [
 
 { #category : 'accessing' }
 IceTipTreeNode >> icon [
-	^ icon
+	^ self iconFormSet ifNotNil: [ :formSet | formSet asForm ]
 ]
 
 { #category : 'accessing' }
-IceTipTreeNode >> icon: anIcon [
-	icon := anIcon
+IceTipTreeNode >> icon: aForm [
+	self iconFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
+]
+
+{ #category : 'accessing' }
+IceTipTreeNode >> iconFormSet [
+	^ iconFormSet
+]
+
+{ #category : 'accessing' }
+IceTipTreeNode >> iconFormSet: aFormSet [
+	iconFormSet := aFormSet
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This pull request refactors IceTipTreeNode to support use of a FormSet (introduced in [Pharo pull request #14998](https://github.com/pharo-project/pharo/pull/14998)) for the icon and applies that to `#repositoryModelsByGroup` on IceTipRepositoryModel.