### PR TITLE
Factor out #iconName from #icon on classes in the IceDefinition, IceOperation and IceOperationMerge hierarchies

### DIFF
--- a/Iceberg-TipUI/IceAddition.extension.st
+++ b/Iceberg-TipUI/IceAddition.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'IceAddition' }
 
 { #category : '*Iceberg-TipUI' }
-IceAddition >> icon [
+IceAddition >> iconName [
 	
-	^ self iconNamed: #changeAdd
+	^ #changeAdd
 ]

--- a/Iceberg-TipUI/IceClassDefinition.extension.st
+++ b/Iceberg-TipUI/IceClassDefinition.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'IceClassDefinition' }
 
 { #category : '*Iceberg-TipUI' }
-IceClassDefinition >> icon [
-	^ self iconNamed: #class
+IceClassDefinition >> iconName [
+	^ #class
 ]

--- a/Iceberg-TipUI/IceConflictingOperation.extension.st
+++ b/Iceberg-TipUI/IceConflictingOperation.extension.st
@@ -1,8 +1,8 @@
 Extension { #name : 'IceConflictingOperation' }
 
 { #category : '*Iceberg-TipUI' }
-IceConflictingOperation >> operationIcon [
-	^ self iconNamed: #changeUpdate
+IceConflictingOperation >> operationIconName [
+	^ #changeUpdate
 ]
 
 { #category : '*Iceberg-TipUI' }

--- a/Iceberg-TipUI/IceDefinition.extension.st
+++ b/Iceberg-TipUI/IceDefinition.extension.st
@@ -3,5 +3,11 @@ Extension { #name : 'IceDefinition' }
 { #category : '*Iceberg-TipUI' }
 IceDefinition >> icon [
 	
+	^ self iconNamed: self iconName
+]
+
+{ #category : '*Iceberg-TipUI' }
+IceDefinition >> iconName [
+	
 	self subclassResponsibility
 ]

--- a/Iceberg-TipUI/IceDirectoryDefinition.extension.st
+++ b/Iceberg-TipUI/IceDirectoryDefinition.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'IceDirectoryDefinition' }
 
 { #category : '*Iceberg-TipUI' }
-IceDirectoryDefinition >> icon [
-	^ self iconNamed: #emptyPackage
+IceDirectoryDefinition >> iconName [
+	^ #emptyPackage
 ]

--- a/Iceberg-TipUI/IceExtensionDefinition.extension.st
+++ b/Iceberg-TipUI/IceExtensionDefinition.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'IceExtensionDefinition' }
 
 { #category : '*Iceberg-TipUI' }
-IceExtensionDefinition >> icon [
-	^ self iconNamed: #group
+IceExtensionDefinition >> iconName [
+	^ #group
 ]

--- a/Iceberg-TipUI/IceFileDefinition.extension.st
+++ b/Iceberg-TipUI/IceFileDefinition.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'IceFileDefinition' }
 
 { #category : '*Iceberg-TipUI' }
-IceFileDefinition >> icon [
-	^ self iconNamed: #book
+IceFileDefinition >> iconName [
+	^ #book
 ]

--- a/Iceberg-TipUI/IceMethodDefinition.extension.st
+++ b/Iceberg-TipUI/IceMethodDefinition.extension.st
@@ -21,7 +21,7 @@ IceMethodDefinition >> canBrowseReferences [
 ]
 
 { #category : '*Iceberg-TipUI' }
-IceMethodDefinition >> icon [
+IceMethodDefinition >> iconName [
 	
-	^ self iconNamed: #changeUpdate
+	^ #changeUpdate
 ]

--- a/Iceberg-TipUI/IceModification.extension.st
+++ b/Iceberg-TipUI/IceModification.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'IceModification' }
 
 { #category : '*Iceberg-TipUI' }
-IceModification >> icon [
+IceModification >> iconName [
 	
-	^ self iconNamed: #changeUpdate
+	^ #changeUpdate
 ]

--- a/Iceberg-TipUI/IceNoModification.extension.st
+++ b/Iceberg-TipUI/IceNoModification.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'IceNoModification' }
 
 { #category : '*Iceberg-TipUI' }
-IceNoModification >> icon [
+IceNoModification >> iconName [
 
-	^ definition icon
+	^ definition iconName
 ]

--- a/Iceberg-TipUI/IceNonConflictingOperation.extension.st
+++ b/Iceberg-TipUI/IceNonConflictingOperation.extension.st
@@ -1,9 +1,9 @@
 Extension { #name : 'IceNonConflictingOperation' }
 
 { #category : '*Iceberg-TipUI' }
-IceNonConflictingOperation >> operationIcon [
+IceNonConflictingOperation >> operationIconName [
 	
-	^ operation icon
+	^ operation iconName
 ]
 
 { #category : '*Iceberg-TipUI' }

--- a/Iceberg-TipUI/IceOperation.extension.st
+++ b/Iceberg-TipUI/IceOperation.extension.st
@@ -21,6 +21,12 @@ IceOperation >> canBrowseReferences [
 { #category : '*Iceberg-TipUI' }
 IceOperation >> icon [
 	
+	^ self iconNamed: self iconName
+]
+
+{ #category : '*Iceberg-TipUI' }
+IceOperation >> iconName [
+	
 	self subclassResponsibility
 ]
 

--- a/Iceberg-TipUI/IceOperationMerge.extension.st
+++ b/Iceberg-TipUI/IceOperationMerge.extension.st
@@ -3,13 +3,19 @@ Extension { #name : 'IceOperationMerge' }
 { #category : '*Iceberg-TipUI' }
 IceOperationMerge >> icon [
 
-	self isRightChosen ifTrue: [ ^ self iconNamed: #changeBlock ].
-	self isLeftChosen ifTrue: [ ^ self iconNamed: #forward ].
-	
-	^ self operationIcon
+	^ self iconNamed: self iconName
 ]
 
 { #category : '*Iceberg-TipUI' }
-IceOperationMerge >> operationIcon [
+IceOperationMerge >> iconName [
+
+	self isRightChosen ifTrue: [ ^ #changeBlock ].
+	self isLeftChosen ifTrue: [ ^ #forward ].
+	
+	^ self operationIconName
+]
+
+{ #category : '*Iceberg-TipUI' }
+IceOperationMerge >> operationIconName [
 	self subclassResponsibility
 ]

--- a/Iceberg-TipUI/IcePackageDefinition.extension.st
+++ b/Iceberg-TipUI/IcePackageDefinition.extension.st
@@ -20,6 +20,6 @@ IcePackageDefinition >> canBrowseReferences [
 ]
 
 { #category : '*Iceberg-TipUI' }
-IcePackageDefinition >> icon [
-	^ self iconNamed: #package
+IcePackageDefinition >> iconName [
+	^ #package
 ]

--- a/Iceberg-TipUI/IceRemoval.extension.st
+++ b/Iceberg-TipUI/IceRemoval.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'IceRemoval' }
 
 { #category : '*Iceberg-TipUI' }
-IceRemoval >> icon [
+IceRemoval >> iconName [
 
-	^ self iconNamed: #changeRemove
+	^ #changeRemove
 ]

--- a/Iceberg-TipUI/IceTraitDefinition.extension.st
+++ b/Iceberg-TipUI/IceTraitDefinition.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'IceTraitDefinition' }
 
 { #category : '*Iceberg-TipUI' }
-IceTraitDefinition >> icon [
-	^ self iconNamed: #trait
+IceTraitDefinition >> iconName [
+	^ #trait
 ]


### PR DESCRIPTION
This pull request factors out `#iconName` from `#icon` on the classes in the IceDefinition, IceOperation and IceOperationMerge hierarchies.

This should make it easier to, in a later pull request, make the `#changeListColumn` methods use the FormSet for each icon for the SpImageTableColumn. I did not include such a change in this pull request for the same reason as in [pull request #1808 (second comment)](https://github.com/pharo-vcs/iceberg/pull/1808#issuecomment-1963107141).