### PR TITLE
Add missing newInform to `visitCloneRemoteNotFound:` dialog

### DIFF
--- a/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
+++ b/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
@@ -87,7 +87,7 @@ IceTipInteractiveErrorVisitor >> visitCloneLocationAlreadyExists: anError [
 { #category : 'visiting' }
 IceTipInteractiveErrorVisitor >> visitCloneRemoteNotFound: anError [
 
-	context application
+	context application newInform
 		label: ('The clone remote {1} could not been found' format:
 				 { anError remoteUrl });
 		title: 'Clone action failed';


### PR DESCRIPTION
This PR fixes the problem reported in https://github.com/pharo-project/pharo/issues/14648. The fixes now correctly open a dialog to inform the error when a remote repository wasn't found.
