### PR TITLE
Added more filtering to Git Repositories Browser

### DIFF
--- a/Iceberg-TipUI/IceTipRepositoryGroupPanel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryGroupPanel.class.st
@@ -61,9 +61,11 @@ IceTipRepositoryGroupPanel >> defaultOutputPort [
 
 { #category : 'private' }
 IceTipRepositoryGroupPanel >> filteredItemsFor: pattern [
-
-	^ self allListItems select: [ :each | 
-		  each name asLowercase includesSubstring: pattern asLowercase ]
+	|orStrings|
+	orStrings := (pattern trim asLowercase substrings: '||') collect: #trim.
+	
+	^ self allListItems select: [ :repository | 
+		  orStrings anySatisfy: [:subPattern | repository name asLowercase includesSubstring: subPattern] ]
 ]
 
 { #category : 'testing' }
@@ -85,7 +87,7 @@ IceTipRepositoryGroupPanel >> initializeRepositoryFilter [
 
 	repositoryFilter := self newTextInput.
 	repositoryFilter 
-		placeholder: 'Filter...';
+		placeholder: 'Filter: name1 || name2 || name3 ...';
 		whenTextChangedDo: [ :text | self refreshRepositoryList ]
 		
 ]


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/16298
"name1 || name2" shows results containing name1 or name2.
 "*" isn't needed as "name1" and "name2" can already be anywhere in the full names of the repos.