### PR TITLE
Remove unused author

### DIFF
--- a/Iceberg/IceMCVersionInfo.class.st
+++ b/Iceberg/IceMCVersionInfo.class.st
@@ -55,21 +55,19 @@ IceMCVersionInfo >> fromCommit: aCommit package: aPackage [
 	"See #fromPackage:message:"
 	commit := aCommit.
 	package := aPackage.
-	
+
    	date := commit datetime asDate.
    	time := commit datetime asTime.
-	
+
 	name := ('{1}-{2}.{3}' format: {
 		package name. 
 		commit compatibleUsername. 
 		commit datetime asUnixTime 
 	}).
-	
+
 	id := self class uuidFromCommit: aCommit package: aPackage.
 
-   	message := commit comment.
-   	author := commit compatibleUsername
-
+   	message := commit comment
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
IceMCVersionInfo is the only thing in the Pharo image still referencing the #author ivar. I propose to remove it so that we can remove the ivar from Monticello