### PR TITLE
Add Alerts to Iceberg's IceTipNewRepositoryPanel to Inform User of Incomplete Information

### DIFF
--- a/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
@@ -163,12 +163,27 @@ IceTipGitProviderRepositoryPanel >> userNameLabel [
 
 { #category : 'accessing' }
 IceTipGitProviderRepositoryPanel >> validate [
-
-	self
+	
+	self userName isNotEmpty 
+	 	ifFalse: [ 
+			self alert: 'You must enter an owner (e.g. username).'. 
+			^false].
+	
+	"self
+		alert: 'You must enter a GitHub owner (e.g. username).'.
 		assert: self userName isNotEmpty
-		description: 'You must enter a GitHub owner (e.g. username).'.
-	self
+		description: 'You must enter a GitHub owner (e.g. username).'."
+		
+		
+	self projectName isNotEmpty 
+	 	ifFalse: [ 
+			self alert: 'You must enter a project name.'. 
+			^false].	
+	"self
+		alert: 'You must enter a GitHub owner (e.g. username).'.
 		assert: self projectName isNotEmpty
-		description: 'You must enter a GitHub project name.'.
-	super validate
+		description: 'You must enter a GitHub project name.'."
+		
+	super validate.
+	^true.
 ]

--- a/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
@@ -85,14 +85,16 @@ IceTipGitRepositoryPanel >> validate [
 
 	| remoteString |
 	remoteString := self remoteUrl.
-	self
-		assert: remoteString isNotEmpty
-		description: 'You must enter your project url.'.
-	self
-		assert: (IceGitRemote isValidUrl: remoteString)
-		description: 'The url is incorrect.'.
-	self
-		assert: self projectLocation location isNotNil
-		description:
-		'Project location must be defined (if it does not exists, it will be created).'
+	remoteString isNotEmpty ifFalse: [
+		self alert: 'You must enter your project url.'.
+		^ false ].
+	(IceGitRemote isValidUrl: remoteString) ifFalse: [
+		self alert: 'You must enter your project url.'.
+		^ false ].
+
+	self projectLocation location ifNil: [
+		self alert:
+			'Project location must be defined (if it does not exists, it will be created).'.
+		^ false ].
+	^ true
 ]

--- a/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
@@ -133,10 +133,21 @@ IceTipNewRepositoryPanel >> titleForWindow [
 { #category : 'accessing' }
 IceTipNewRepositoryPanel >> validate [
 
-	self 
-		assert: self projectNameInputText text isNotEmpty  
-		description: 'You must enter a project name (it will be used also as part of the path).'.
+	self projectNameInputText text isNotEmpty ifFalse: [
+		self alert: 'You must enter a project name (it will be used also as part of the path).'.
+		^ false ].
+	
+	self projectLocation location isNotNil ifFalse: [
+		self alert: 'You must enter a project name (it will be used also as part of the path).'.
+		^ false ].
+	^true.
+
+	"self
+		assert: self projectNameInputText text isNotEmpty
+		description:
+		'You must enter a project name (it will be used also as part of the path).'.
 	self
-		assert: self projectLocation location isNotNil  
-		description: 'Project location must be defined (if it does not exists, it will be created).'
+		assert: self projectLocation location isNotNil
+		description:
+		'Project location must be defined (if it does not exists, it will be created).'"
 ]

--- a/Iceberg-TipUI/IceTipRegisterRepositoryDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipRegisterRepositoryDialogPresenter.class.st
@@ -19,6 +19,17 @@ Class {
 	#tag : 'View-Repository'
 }
 
+{ #category : 'actions' }
+IceTipRegisterRepositoryDialogPresenter >> accept [
+
+	[
+	self doAccept ifFalse: [ ^ false ].
+	self closeWindow ]
+		on: IceError , IceWarning
+		do: [ :e |
+			e acceptError: (IceTipInteractiveErrorVisitor newContext: self) ]
+]
+
 { #category : 'accessing' }
 IceTipRegisterRepositoryDialogPresenter >> allTypes [
 
@@ -37,7 +48,7 @@ IceTipRegisterRepositoryDialogPresenter >> beForCloneOfRepository: aRepository [
 IceTipRegisterRepositoryDialogPresenter >> doAccept [
 
 	| newRepository |
-	self selectedType validate.
+	(self selectedType validate) ifFalse: [^false].
 	self isEditing ifTrue: [ self selectedType repository: repository ].
 	newRepository := self selectedType newRepository.
 	self isEditing ifFalse: [ newRepository register ].


### PR DESCRIPTION
Fixes #16870

I have enhanced the validate methods by adding alerts to inform users about the necessary actions to continue. To allow the dialog to remain open, I had to modify the caller of validate.

This replaces the behavior of opening a debugging window on the failure of the assert calls. 

Issue: 
https://github.com/pharo-project/pharo/issues/16870