### PR TITLE
Remove FastTable #isRoot methods

### DIFF
--- a/Iceberg-TipUI/FTRootItem.extension.st
+++ b/Iceberg-TipUI/FTRootItem.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'FTRootItem' }
-
-{ #category : '*Iceberg-TipUI' }
-FTRootItem >> isRoot [
-	^ true
-]

--- a/Iceberg-TipUI/FTTreeItem.extension.st
+++ b/Iceberg-TipUI/FTTreeItem.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'FTTreeItem' }
-
-{ #category : '*Iceberg-TipUI' }
-FTTreeItem >> isRoot [
-	^ false
-]


### PR DESCRIPTION
Those methods are already in Pharo and Iceberg clashes with that so we should just remove them (They are identic)