### PR TITLE
Add method history browser context menu item for browsing the selected commit in the repository browser

### DIFF
--- a/Iceberg-TipUI/IceTipBrowseCommitCommand.class.st
+++ b/Iceberg-TipUI/IceTipBrowseCommitCommand.class.st
@@ -1,0 +1,28 @@
+"
+Command that opens a Repository Browser on the selected commit.
+"
+Class {
+	#name : 'IceTipBrowseCommitCommand',
+	#superclass : 'IceTipCommand',
+	#category : 'Iceberg-TipUI-Commands',
+	#package : 'Iceberg-TipUI',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+IceTipBrowseCommitCommand class >> defaultName [
+
+	^ 'Browse commit'
+]
+
+{ #category : 'execution' }
+IceTipBrowseCommitCommand >> commit [
+
+	^ self item commit
+]
+
+{ #category : 'executing' }
+IceTipBrowseCommitCommand >> execute [
+
+	IceTipRepositoryBrowser openOnCommit: self commit
+]

--- a/Iceberg-TipUI/IceTipHistoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipHistoryBrowser.class.st
@@ -152,6 +152,13 @@ IceTipHistoryBrowser >> refreshTags [
 	commitList refresh
 ]
 
+{ #category : 'selection' }
+IceTipHistoryBrowser >> selectCommit: commit scrollToSelection: shouldScrollToSelection [
+
+	self commitList selectIndex: (self commitList items detectIndex: [ :item | item commit = commit ])
+		scrollToSelection: shouldScrollToSelection
+]
+
 { #category : 'accessing' }
 IceTipHistoryBrowser >> selectedCommit [
 

--- a/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
@@ -69,6 +69,15 @@ IceTipRepositoryBrowser class >> onRepositoryNamed: aString [
 	^ self onRepository: (IceRepository registry detect: [ :each | each name = aString ])
 ]
 
+{ #category : 'opening' }
+IceTipRepositoryBrowser class >> openOnCommit: commit [
+
+	^ (self onRepository: commit repository)
+		open;
+		selectCommit: commit scrollToSelection: true;
+		yourself
+]
+
 { #category : 'event handling' }
 IceTipRepositoryBrowser >> commitishSelected: ann [
 
@@ -153,6 +162,12 @@ IceTipRepositoryBrowser >> refreshWhenRepository: ann [
 	(self model isModelOf: ann repository) ifFalse: [ ^ self ].
 	self model reset.
 	self updatePresenter
+]
+
+{ #category : 'selection' }
+IceTipRepositoryBrowser >> selectCommit: commit scrollToSelection: shouldScrollToSelection [
+
+	self historyPanel selectCommit: commit scrollToSelection: shouldScrollToSelection
 ]
 
 { #category : 'initialization' }

--- a/Iceberg-TipUI/IceTipVersionHistoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipVersionHistoryBrowser.class.st
@@ -31,7 +31,7 @@ IceTipVersionHistoryBrowser class >> buildGeneralCommandGroupWith: presenter for
 { #category : 'commands' }
 IceTipVersionHistoryBrowser class >> buildSelectionCommandGroupWith: presenter for: aCommandGroup [
 
-	{ 	IceTipInstallVersionCommand }
+	{ 	IceTipInstallVersionCommand. IceTipBrowseCommitCommand }
 			do: [ :each |
 				aCommandGroup register: (each forSpecContext: presenter) ]
 


### PR DESCRIPTION
When looking at the history of a method, I often want to see the wider context: what else was changed in the same commit, and what commits were done before and after. To support that, this pull request extends the commit list context menu in the window showing the history of a method with a menu item ‘Browse commit’ that opens a repository browser on the corresponding repository and selects the same commit. The first of the following two screenshots shows an example of using the menu item and the second one shows the repository browser that is opened:

<p align="center">
<img width="439" src="https://github.com/user-attachments/assets/873a0640-d487-4c8f-ac3a-a0f77a825352">
</p>

<p align="center">
<img width="453" src="https://github.com/user-attachments/assets/89b19c84-599f-4e5e-bab8-8129c48b576c">
</p>