### PR TITLE
Cut setting Morphic dependency

### DIFF
--- a/Iceberg-TipUI/IceTipCredentialsSettings.class.st
+++ b/Iceberg-TipUI/IceTipCredentialsSettings.class.st
@@ -26,15 +26,10 @@ IceTipCredentialsSettings class >> editButtonState [
 IceTipCredentialsSettings class >> settingsOn: aBuilder [
 	<systemsettings>
 
-	(aBuilder group: #EditCredentials)
+	(aBuilder button: #editButtonAction)
 		parent: #icebergCredentials;
 		noOrdering;
 		target: self;
 		label: 'Current list of credentials';
-		dialog: [
-			PluggableButtonMorph
-				on: self
-				getState: nil
-				action: #editButtonAction
-				label: #editButtonLabel ]
+		buttonLabel: self editButtonLabel 
 ]


### PR DESCRIPTION
Cut `IceTipCredentialsSettings class>>#settingsOn:` dependency on Morphic (needed by the new SettingBrowser). The change is compatible with both the old Setting Browser and the new Setting Browser.
