### PR TITLE
Fixes # 1861 on Pharo : location not a git repo when Importing existing clone

### DIFF
--- a/Iceberg-TipUI/IceTipLocalRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipLocalRepositoryPanel.class.st
@@ -90,7 +90,5 @@ IceTipLocalRepositoryPanel >> validate [
 	self
 		assert: self location exists
 		description: 'Project location must exist!'.
-	self
-		assert: (IceRepositoryCreator isGitRoot: self location)
-		description: 'Project location does not seems to be a valid git repository.'
+
 ]

--- a/Iceberg-TipUI/IceTipOptionDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipOptionDialogPresenter.class.st
@@ -23,15 +23,11 @@ Class {
 IceTipOptionDialogPresenter >> accept [
 
 	[
-	self selectedType class = IceTipLocalRepositoryPanel
+	(self selectedType class = IceTipLocalRepositoryPanel and: [
+		 (IceRepositoryCreator isGitRoot: self selectedType location) not ])
 		ifTrue: [
-			(IceRepositoryCreator isGitRoot: self selectedType location)
-				ifFalse: [
-					self inform: ('"{1}" git repository not found' format:
-							 { self selectedType location fullName }) ]
-				ifTrue: [
-					self doAccept.
-					self closeWindow ] ]
+			self inform: ('"{1}" git repository not found' format:
+					 { self selectedType location fullName }) ]
 		ifFalse: [
 			self doAccept.
 			self closeWindow ] ]

--- a/Iceberg-TipUI/IceTipOptionDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipOptionDialogPresenter.class.st
@@ -22,12 +22,22 @@ Class {
 { #category : 'actions' }
 IceTipOptionDialogPresenter >> accept [
 
-	[ 
-	  self doAccept.
-	  self closeWindow ]
-		  on: IceError , IceWarning
-		  do: [ :e | 
-			  e acceptError: (IceTipInteractiveErrorVisitor newContext: self) ]
+	[
+	self selectedType class = IceTipLocalRepositoryPanel
+		ifTrue: [
+			(IceRepositoryCreator isGitRoot: self selectedType location)
+				ifFalse: [
+					self inform: ('"{1}" git repository not found' format:
+							 { self selectedType location fullName }) ]
+				ifTrue: [
+					self doAccept.
+					self closeWindow ] ]
+		ifFalse: [
+			self doAccept.
+			self closeWindow ] ]
+		on: IceError , IceWarning
+		do: [ :e |
+			e acceptError: (IceTipInteractiveErrorVisitor newContext: self) ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #1861 
Actually maybe the **accept** method is a bit full now, but I think it's the easiest way to have the wanted behavior.
@Ducasse now when selecting a location that is not a git repo we just have this : 
![Screen Shot 2024-11-25 at 14 25 03](https://github.com/user-attachments/assets/0bffd444-967f-4f30-a381-b32721cddbf1)
