### PR TITLE
Make #addFilesToIndex: on IceLibgitRepository refresh the index before adding the files

### DIFF
--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -204,6 +204,7 @@ IceLibgitRepository >> addFilesToIndex: aCollection [
 		| gitIndex |
 		gitIndex := self repositoryHandle index.
 		gitIndex
+			refresh;
 			addAll:
 				(aCollection
 					collect: [ :each | 


### PR DESCRIPTION
This pull request makes `#addFilesToIndex:` on IceLibgitRepository refresh the index before adding the files as suggested [in issue 1691](https://github.com/pharo-vcs/iceberg/issues/1691#issuecomment-1482080760). Before this can be merged, [libgit2-pharo-bindings pull request #91](https://github.com/pharo-vcs/libgit2-pharo-bindings/pull/91) needs to be merged first.