### PR TITLE
Make #importOn: on IceGitChangeImporter take into account that the ‘fileReference’ is not necessarily a file when the size of the ‘path’ is 1

### DIFF
--- a/Iceberg-Libgit/IceGitChangeImporter.class.st
+++ b/Iceberg-Libgit/IceGitChangeImporter.class.st
@@ -70,10 +70,10 @@ IceGitChangeImporter >> importOn: aNode [
 	For now, we only support packages inside the declared subdirectory (or root otherwise).
 	All other changes are simple directory/file changes"
 	
-	"If path = 1 this means it is a file"
+	"If path = 1 this means it is not a directory"
 	path size = 1
 		ifTrue: [ 
-				fileReference exists ifTrue: [
+				(fileReference exists and: [ fileReference isFile ]) ifTrue: [
 				^ aNode addChild: (IceFileDefinition named: currentSegment path: filePath fileReference: fileReference) ] ].
 	
 	path size > 1 ifTrue: [ | directoryReference directoryPath |


### PR DESCRIPTION
This pull request makes #importOn: on IceGitChangeImporter take into account that the ‘fileReference’ is not necessarily a file when the size of the ‘path’ is 1. Like [libgit2-pharo-bindings pull request #93](https://github.com/pharo-vcs/libgit2-pharo-bindings/pull/93), this avoids the signaling of a LGit_GIT_ENOTFOUND for [git submodules](https://git-scm.com/docs/gitsubmodules). For now, a submodule is just ignored and doesn’t appear in commit diffs.