### PR TITLE
Pharo13.0.0: #chore: Changed the automatic comment in commit message

### DIFF
--- a/Iceberg-TipUI/IceTipCommentPanel.class.st
+++ b/Iceberg-TipUI/IceTipCommentPanel.class.st
@@ -61,8 +61,6 @@ IceTipCommentPanel >> defaultLayout [
 				   yourself)
 		  expand: false;
 		  add: commentText;
-		  add: fixesLabel expand: false;
-		  add: fixesField expand: false;
 		  add: actionButtonBar expand: false;
 		  yourself
 ]
@@ -121,10 +119,11 @@ IceTipCommentPanel >> initializePresenters [
 		               text:
 			               SystemVersion current majorMinorVersion , ':'
 			               , String cr , String cr , '#Branch: '
-			               , repositoryModel branchName , String cr
-			               , '#Please use one of those' , String cr , '#feat:'
-			               , String cr , '#fix:' , String cr , '#refactor:'
-			               , String cr , '#chore:' , String cr , '#comment:';
+			               , repositoryModel branchName , ' Fixes #'
+			               , String cr , '#Please use one of those' , String cr
+			               , '#feat:' , String cr , '#fix:' , String cr
+			               , '#refactor:' , String cr , '#chore:' , String cr
+			               , '#comment:';
 		               yourself.
 
 	fixesHelpString := 'Enter the number of the issue that you fixed. Github will close it when it will be committed or merged in the default branch'.

--- a/Iceberg-TipUI/IceTipCommentPanel.class.st
+++ b/Iceberg-TipUI/IceTipCommentPanel.class.st
@@ -117,8 +117,9 @@ IceTipCommentPanel >> initializePresenters [
 
 	commentText := self newText
 		               text:
-			               SystemVersion current majorMinorVersion , ':'
-			               , String cr , String cr , '#Branch: '
+			               String cr , String cr
+			               , SystemVersion current majorMinorVersion , ':'
+			               , String cr , '#Branch: '
 			               , repositoryModel branchName , ' Fixes #'
 			               , String cr , '#Please use one of those' , String cr
 			               , '#feat:' , String cr , '#fix:' , String cr

--- a/Iceberg-TipUI/IceTipCommentPanel.class.st
+++ b/Iceberg-TipUI/IceTipCommentPanel.class.st
@@ -53,16 +53,18 @@ IceTipCommentPanel >> defaultLayout [
 	migration from Spec1+Commander1 to Spec2+Commander2)."
 
 	^ SpBoxLayout newTopToBottom
-		spacing: 5;
-		add: (SpBoxLayout newLeftToRight
-				vAlignCenter;
-				add: pushCheckbox;
-				addLast: optionsButton expand: false;
-				yourself)
-		  	expand: false;
-		add: commentText;
-		add: actionButtonBar expand: false;
-		yourself
+		  spacing: 5;
+		  add: (SpBoxLayout newLeftToRight
+				   vAlignCenter;
+				   add: pushCheckbox;
+				   addLast: optionsButton expand: false;
+				   yourself)
+		  expand: false;
+		  add: commentText;
+		  add: fixesLabel expand: false;
+		  add: fixesField expand: false;
+		  add: actionButtonBar expand: false;
+		  yourself
 ]
 
 { #category : 'accessing' }
@@ -115,9 +117,15 @@ IceTipCommentPanel >> initializePresenters [
 					'Cannot push new branch automatically. Use the `Push` option';
 				enabled: false ].
 
-	commentText := self newText text:
-		               'Branch: ' , repositoryModel branchName
-		               , ',  Fixes # ' yourself.
+	commentText := self newText
+		               text:
+			               SystemVersion current majorMinorVersion , ':'
+			               , String cr , String cr , '#Branch: '
+			               , repositoryModel branchName , String cr
+			               , '#Please use one of those' , String cr , '#feat:'
+			               , String cr , '#fix:' , String cr , '#refactor:'
+			               , String cr , '#chore:' , String cr , '#comment:';
+		               yourself.
 
 	fixesHelpString := 'Enter the number of the issue that you fixed. Github will close it when it will be committed or merged in the default branch'.
 	fixesLabel := self newLabel


### PR DESCRIPTION
-Added the fixes# with issue number labels
-Put the current version of Pharo at the beggining of commit title, can be very useful if somebody searches a bug for example -Added all types of commit as comment, to have a clean way to work it would be better to use one of these types for each commit to detail what people have done.
@Ducasse or @jecisc let me know!