### PR TITLE
Update version in #libgit: for BaselineOfIceberg for Pharo 12 to ‘v3.1.2’

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -76,7 +76,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.1.1';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.1.2';
   			loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'


### PR DESCRIPTION
This pull request updates the version in #libgit: for BaselineOfIceberg for Pharo 12 to ‘v3.1.2’.

Before merging this please:
* Merge libgit2-pharo-bindings pull requests [#94](https://github.com/pharo-vcs/libgit2-pharo-bindings/pull/94), [#95](https://github.com/pharo-vcs/libgit2-pharo-bindings/pull/95) and [#96](https://github.com/pharo-vcs/libgit2-pharo-bindings/pull/96).
* Tag the resulting ‘Pharo12’ commit in libgit2-pharo-bindings as ‘v3.1.2’.
* Fix the ‘Pharo12’ branch for Iceberg: as noted [in pull request #1843](https://github.com/pharo-vcs/iceberg/pull/1843#issuecomment-2692648270), it currently refers to commit f50bc4ca7581315e, which doesn’t seem correct as that changed the ‘test-all.yml’ workflow to use Pharo 13. I would suggest to reset it to commit 4a53622664aa429f, which is the commit used in Pharo 12 build 1564. I started the branch for this pull request from that same commit.