### PR TITLE
Backport changes making #addFilesToIndex: on IceLibgitRepository refresh the index to Pharo 12

### DIFF
--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -204,6 +204,7 @@ IceLibgitRepository >> addFilesToIndex: aCollection [
 		| gitIndex |
 		gitIndex := self repositoryHandle index.
 		gitIndex
+			refresh;
 			addAll:
 				(aCollection
 					collect: [ :each | 


### PR DESCRIPTION
This pull request backports the changes of pull request #1895 to Pharo 12.

Before merging this please:
* Merge pull request [#1900](https://github.com/pharo-vcs/iceberg/pull/1900). Note that that still requires fixing the ‘Pharo12’ branch first.