### PR TITLE
Backport changes making #importOn: on IceGitChangeImporter take into account that the ‘fileReference’ is not necessarily a file when the size of the ‘path’ is 1 to Pharo 12

### DIFF
--- a/Iceberg-Libgit/IceGitChangeImporter.class.st
+++ b/Iceberg-Libgit/IceGitChangeImporter.class.st
@@ -70,10 +70,10 @@ IceGitChangeImporter >> importOn: aNode [
 	For now, we only support packages inside the declared subdirectory (or root otherwise).
 	All other changes are simple directory/file changes"
 	
-	"If path = 1 this means it is a file"
+	"If path = 1 this means it is not a directory"
 	path size = 1
 		ifTrue: [ 
-				fileReference exists ifTrue: [
+				(fileReference exists and: [ fileReference isFile ]) ifTrue: [
 				^ aNode addChild: (IceFileDefinition named: currentSegment path: filePath fileReference: fileReference) ] ].
 	
 	path size > 1 ifTrue: [ | directoryReference directoryPath |


### PR DESCRIPTION
This pull request backports the changes of pull request #1896 to Pharo 12.

Before merging this please:
* Merge pull request [#1900](https://github.com/pharo-vcs/iceberg/pull/1900). Note that that still requires fixing the ‘Pharo12’ branch first.