### PR TITLE
Keep dirty packages when cloning Pharo

### DIFF
--- a/Iceberg-Libgit/IceRepositoryCreator.class.st
+++ b/Iceberg-Libgit/IceRepositoryCreator.class.st
@@ -93,14 +93,13 @@ IceRepositoryCreator >> cloneRepository [
 		location: self locationToUse;
 		url: self remoteToUse url;
 		execute.
+
 	self repository location: self locationToUse.
 		
-	self commitishName 
-		ifNotNil: [ self repository switchToCommitishNamed: self commitishName ].
 	self repository pluginManager repositoryWillBeCreated: self repository.	
 
-	self doEnsureProject.
 	self repository workingCopy initializePackagesFromRepository.
+	self doEnsureProject.
 		
 	self repository pluginManager repositoryWasCreated: self repository.
 	^ self repository

--- a/Iceberg-Plugin-Pharo/IcePharoPlugin.class.st
+++ b/Iceberg-Plugin-Pharo/IcePharoPlugin.class.st
@@ -193,13 +193,3 @@ IcePharoPlugin >> fetchIfNeeded: aRepository [
 				detect: [ :each | each projectName = 'pharo-project' ]
 				ifFound: [ :each | each fetch ] ]
 ]
-
-{ #category : 'events' }
-IcePharoPlugin >> repositoryWillBeCreated: aRepository [
-	
-	"this is just supported on Pharo 8+"
-	SystemVersion current major < 7 ifTrue: [ ^ self ].
-	
-	self fetchIfNeeded: aRepository.
-	(aRepository lookupCommit: SystemVersion current commitHash) adopt.
-]


### PR DESCRIPTION
Make project  repository clone work the same as attaching a repository in disk.

Turns out that the code of the Pharo plugin was duplicated and called twice, which was creating reloading package meta-data twice and losing the dirty flags.