### PR TITLE
Adjusted layout width of IceTipSelectRemotePresenter

### DIFF
--- a/Iceberg-TipUI/IceTipSelectRemotePresenter.class.st
+++ b/Iceberg-TipUI/IceTipSelectRemotePresenter.class.st
@@ -37,7 +37,7 @@ IceTipSelectRemotePresenter >> defaultLayout [
 
 	^ SpBoxLayout newLeftToRight
 		spacing: 3;
-		add: remoteList;
+		add: remoteList width: 280;
 		add: addButton expand: false;
 		add: self newNullPresenter  expand: false;
 		yourself


### PR DESCRIPTION
- Set the width of ```remoteList``` to not have the glitch of the ```addButton``` anymore 
- Fixes: #1893