### PR TITLE
Deleted useless call

### DIFF
--- a/Iceberg-TipUI/TWithBranchModel.trait.st
+++ b/Iceberg-TipUI/TWithBranchModel.trait.st
@@ -29,8 +29,3 @@ TWithBranchModel >> defaultBranchSelection [
 TWithBranchModel >> hasBranches [ 
 	^ self branches isNotEmpty
 ]
-
-{ #category : 'accessing' }
-TWithBranchModel >> repositoryModel [ 
-	^ self explicitRequirement
-]


### PR DESCRIPTION
Fixes: #1860
Removed this method since  Object>>#explicitRequirement is deprecated and will be removed