### PR TITLE
RemoteModel should define repositoryModel (explicit trait requirement)

### DIFF
--- a/Iceberg-TipUI/IceTipRemoteModel.class.st
+++ b/Iceberg-TipUI/IceTipRemoteModel.class.st
@@ -30,6 +30,12 @@ IceTipRemoteModel >> description [
 	^ '{1} <{2}>' format: { self name. self entity url }
 ]
 
+{ #category : 'comparing' }
+IceTipRemoteModel >> hash [
+
+	^ entity hash
+]
+
 { #category : 'actions' }
 IceTipRemoteModel >> newDeleteAction [
 	

--- a/Iceberg-TipUI/IceTipRemoteModel.class.st
+++ b/Iceberg-TipUI/IceTipRemoteModel.class.st
@@ -4,7 +4,7 @@ I'm a model for IceRemote entries.
 Class {
 	#name : 'IceTipRemoteModel',
 	#superclass : 'IceTipEntityModel',
-	#traits : 'TWithBranchModel',
+	#traits : 'TWithBranchModel - {#repositoryModel}',
 	#classTraits : 'TWithBranchModel classTrait',
 	#category : 'Iceberg-TipUI-Model',
 	#package : 'Iceberg-TipUI',
@@ -50,10 +50,4 @@ IceTipRemoteModel >> newFetchAction [
 		onSuccessRepositoryModified;
 		action: [ self entity fetch ];
 		yourself
-]
-
-{ #category : 'accessing' }
-IceTipRemoteModel >> repositoryModel [ 
-	
-	^ repositoryModel
 ]

--- a/Iceberg-TipUI/IceTipRemoteModel.class.st
+++ b/Iceberg-TipUI/IceTipRemoteModel.class.st
@@ -51,3 +51,9 @@ IceTipRemoteModel >> newFetchAction [
 		action: [ self entity fetch ];
 		yourself
 ]
+
+{ #category : 'accessing' }
+IceTipRemoteModel >> repositoryModel [ 
+	
+	^ repositoryModel
+]


### PR DESCRIPTION
~Just add a getter~

Actually, the issue is that the superclass defines the method.
But the subclass imports the trait and the `explicitRequirement` redefines the method.

I reposted a fix that only not imports the conflicting explicit requirement method.

Also, add a hash to the class that defines equals.