### PR TITLE
fix: don't throw uncaught exceptions when a validation error occurs

### DIFF
--- a/Iceberg-TipUI/IceTipAddRemoteDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipAddRemoteDialogPresenter.class.st
@@ -26,7 +26,10 @@ IceTipAddRemoteDialogPresenter class >> defaultPreferredExtent [
 { #category : 'actions' }
 IceTipAddRemoteDialogPresenter >> accept [
 
-	self validate.
+	[ self validate ]
+		on: IceError , IceWarning
+		do: [ :e |
+			^ e acceptError: (IceTipInteractiveErrorVisitor newContext: self) ].
 	(self model 
 		newAddRemoteActionName: self remoteName 
 		url: self remoteUrl)
@@ -128,16 +131,13 @@ IceTipAddRemoteDialogPresenter >> urlText [
 	^ urlText
 ]
 
-{ #category : 'actions' }
+{ #category : 'validation' }
 IceTipAddRemoteDialogPresenter >> validate [
 
-	self
-		assert: self remoteName isNotEmpty 
-		description: 'You need to specify a remote name.'.
-	self
-		assert: self remoteUrl isNotEmpty
-		description: 'You need to specify a remote url.'
-
+	self remoteName isEmpty ifTrue: [
+		IceError signal: 'You need to specify a remote name.' ].
+	self remoteUrl isEmpty ifTrue: [
+		IceError signal: 'You need to specify a remote url.' ]
 ]
 
 { #category : 'initialization' }

--- a/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
@@ -164,11 +164,11 @@ IceTipGitProviderRepositoryPanel >> userNameLabel [
 { #category : 'accessing' }
 IceTipGitProviderRepositoryPanel >> validate [
 
-	self
-		assert: self userName isNotEmpty
-		description: 'You must enter a GitHub owner (e.g. username).'.
-	self
-		assert: self projectName isNotEmpty
-		description: 'You must enter a GitHub project name.'.
+	self userName isEmpty ifTrue: [
+		IceError signal: 'You must enter a GitHub owner (e.g. username).'.
+	].
+	self projectName isEmpty ifTrue: [
+		IceError signal: 'You must enter a GitHub project name.'.
+	].
 	super validate
 ]

--- a/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
@@ -73,16 +73,13 @@ IceTipGitRepositoryPanel >> validate [
 
 	| remoteString |
 	remoteString := self remoteUrl.
-	self
-		assert: remoteString isNotEmpty
-		description: 'You must enter your project url.'.
-	self
-		assert: (IceGitRemote isValidUrl: remoteString)
-		description: 'The url is incorrect.'.
-	self
-		assert: self projectLocation location isNotNil
-		description:
-		'Project location must be defined (if it does not exists, it will be created).'
+	remoteString isEmpty ifTrue: [
+		IceError signal: 'You must enter your project url.' ].
+	(IceGitRemote isValidUrl: remoteString) ifFalse: [
+		IceError signal: 'The url is incorrect.' ].
+	self projectLocation location ifNil: [
+			IceError signal:
+				'Project location must be defined (if it does not exists, it will be created).' ]
 ]
 
 { #category : 'initialization' }

--- a/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
@@ -121,12 +121,11 @@ IceTipNewRepositoryPanel >> subdirectoryLabel [
 { #category : 'accessing' }
 IceTipNewRepositoryPanel >> validate [
 
-	self 
-		assert: self projectNameInputText text isNotEmpty  
-		description: 'You must enter a project name (it will be used also as part of the path).'.
-	self
-		assert: self projectLocation location isNotNil  
-		description: 'Project location must be defined (if it does not exists, it will be created).'
+	self projectNameInputText text isEmpty ifTrue: [
+		IceError signal: 'You must enter a project name (it will be used also as part of the path).'. 	].
+	self projectLocation location ifNil: [
+		IceError signal: 'Project location must be defined (if it does not exists, it will be created).'
+	].
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Instead throw IceError's, which are caught and show a nice warning

Using IceError's instead of a boolean flag, also avoids the issue raised [here](https://github.com/pharo-vcs/iceberg/pull/1834#issuecomment-2280400959)

Fixes: #16870