### PR TITLE
Remove calls to a deprecated method

### DIFF
--- a/Iceberg-Libgit-Filetree/IceLibgitFiletreeLog.class.st
+++ b/Iceberg-Libgit-Filetree/IceLibgitFiletreeLog.class.st
@@ -70,19 +70,17 @@ IceLibgitFiletreeLog >> definitionFor: aMethod path: aPath commit: aCommit [
 
 { #category : 'private' }
 IceLibgitFiletreeLog >> fileNameForMethod: aMethod [
+
 	| path |
-	
 	path := OrderedCollection new.
-	self repository subdirectory 
-		ifNotEmpty: [ :subDir | path add: subDir ].
-	path 
+	self repository subdirectory ifNotEmpty: [ :subDir | path add: subDir ].
+	path
 		add: (self cypressPackageName: aMethod package);
 		add: (self cypressClassOrTraitName: aMethod);
 		add: (self cypressMethodSideName: aMethod);
 		add: (self cypressMethodName: aMethod).
-	
-	^ String streamContents: [ :stream |
-		path asStringOn: stream delimiter: '/' ]
+
+	^ String streamContents: [ :stream | path do: [ :elem | stream nextPutAll: elem asString ] separatedBy: [ stream nextPutAll: '/' ] ]
 ]
 
 { #category : 'private' }

--- a/Iceberg-Libgit-Tonel/IceLibgitTonelLog.class.st
+++ b/Iceberg-Libgit-Tonel/IceLibgitTonelLog.class.st
@@ -40,16 +40,14 @@ IceLibgitTonelLog >> definitionFor: aMethod path: aPath commit: aCommit [
 
 { #category : 'private' }
 IceLibgitTonelLog >> fileNameForMethod: aMethod [
+
 	| path |
-	
 	path := OrderedCollection new.
-	self repository subdirectory 
-		ifNotEmpty: [ :subDir | path add: subDir ].
+	self repository subdirectory ifNotEmpty: [ :subDir | path add: subDir ].
 	path add: (self tonelPackageName: aMethod package).
 	path add: (self tonelMethodClassOrTraitName: aMethod).
-	
-	^ String streamContents: [ :stream |
-		path asStringOn: stream delimiter: '/' ]
+
+	^ String streamContents: [ :stream | path do: [ :elem | stream nextPutAll: elem asString ] separatedBy: [ stream nextPutAll: '/' ] ]
 ]
 
 { #category : 'private' }

--- a/Iceberg-Metacello-Integration/IceGitLocalRepositoryType.class.st
+++ b/Iceberg-Metacello-Integration/IceGitLocalRepositoryType.class.st
@@ -61,19 +61,17 @@ IceGitLocalRepositoryType >> mcRepository [
 
 { #category : 'private' }
 IceGitLocalRepositoryType >> splitRootAndSubdirectoryFromLocation [
+
 	| root subDir |
-	(self location beginsWith: (self class type, '://'))
-		ifFalse: [ self error: 'Invalid URL (It should be ', self class type, '://...)' ].
+	(self location beginsWith: self class type , '://') ifFalse: [ self error: 'Invalid URL (It should be ' , self class type , '://...)' ].
 	root := (self location allButFirst: self class type size + 3) asFileReference.
-	subDir := #().
-	[ root isRoot or: [ self isGitRoot: root ] ] 
-	whileFalse: [ 
-		(root asAbsolute = FileSystem workingDirectory)
-			ifFalse: [ subDir := subDir copyWithFirst: root basename ].
-		root := root parent ].
+	subDir := #(  ).
+	[ root isRoot or: [ self isGitRoot: root ] ] whileFalse: [
+			root asAbsolute = FileSystem workingDirectory ifFalse: [ subDir := subDir copyWithFirst: root basename ].
+			root := root parent ].
 	root isRoot ifTrue: [ self error: 'I can''t find a .git/config file.' ].
-	
-	^ { 
-		root. "a FileReference"
-		String streamContents: [ :stream | subDir asStringOn: stream delimiter: '/' ] "a String" }
+
+	^ {
+		  root. "a FileReference"
+		  (String streamContents: [ :stream |subDir do: [ :elem | stream nextPutAll: elem asString ] separatedBy: [ stream nextPutAll: '/' ] ])  "a String" }
 ]

--- a/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
+++ b/Iceberg-Plugin-GitHub/IceGitHubNewPullRequestAction.class.st
@@ -61,14 +61,12 @@ IceGitHubNewPullRequestAction >> validateMakePullRequestOn: aRepository [
 	| status |
 	status := OrderedCollection new: 2.
 	aRepository isModified ifTrue: [ status add: 'Uncommitted changes' ].
-	(aRepository outgoingCommitsTo: remote) ifNotEmpty: [ :commits |
-		'{1} not published' format: { commits size } ].
+	(aRepository outgoingCommitsTo: remote) ifNotEmpty: [ :commits | '{1} not published' format: { commits size } ].
 	status ifEmpty: [ ^ true ].
 
 	^ self application newConfirm
-		  title:
-			  ('{1} has ongoing modifications.' format: { aRepository name });
+		  title: ('{1} has ongoing modifications.' format: { aRepository name });
 		  label: ('{2} 
-Do you want to continue anyway?' format: { status asCommaString });
+Do you want to continue anyway?' format: { (', ' join: status) });
 		  openModal
 ]

--- a/Iceberg-TipUI/IceTipCommitModel.class.st
+++ b/Iceberg-TipUI/IceTipCommitModel.class.st
@@ -154,12 +154,14 @@ IceTipCommitModel >> id [
 
 { #category : 'accessing' }
 IceTipCommitModel >> info [
-	^ {('Commit:' -> ('[' , self shortId , '] ' , self id)).
-	('Parents:' -> (self entity ancestors collect: #shortId) asCommaString).
-	('Author:' -> self entity author).
-	('Date:' -> self entity timeStamp asStringYMDHM).
-	('Tags:' -> self entity tagNames asCommaString).
-	('Comment:' -> self entity comment)}
+
+	^ {
+		  ('Commit:' -> ('[' , self shortId , '] ' , self id)).
+		  ('Parents:' -> (', ' join: (self entity ancestors collect: #shortId))).
+		  ('Author:' -> self entity author).
+		  ('Date:' -> self entity timeStamp asStringYMDHM).
+		  ('Tags:' -> (', ' join: self entity tagNames)).
+		  ('Comment:' -> self entity comment) }
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
Found out that iceberg calls a lot a deprecated method while loading a project. This floods my logs.  Let's update it to not call it