### PR TITLE
Fix git direct access to repository

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -80,7 +80,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.2.0';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:Pharo14';
   				loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'
@@ -132,5 +132,5 @@ BaselineOfIceberg >> resetKMRepository [
 BaselineOfIceberg >> tonel: spec [
 	spec
 		baseline: 'Tonel' 
-		with: [ spec repository: 'github://pharo-vcs/tonel:v1.2.0' ]
+		with: [ spec repository: 'github://pharo-vcs/tonel:Pharo14' ]
 ]

--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -80,7 +80,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:Pharo13';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.2.0';
   				loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'
@@ -132,5 +132,5 @@ BaselineOfIceberg >> resetKMRepository [
 BaselineOfIceberg >> tonel: spec [
 	spec
 		baseline: 'Tonel' 
-		with: [ spec repository: 'github://pharo-vcs/tonel:Pharo13' ]
+		with: [ spec repository: 'github://pharo-vcs/tonel:v1.2.0' ]
 ]

--- a/Iceberg-Libgit/IceGitScpRemote.class.st
+++ b/Iceberg-Libgit/IceGitScpRemote.class.st
@@ -56,6 +56,7 @@ IceGitScpRemote >> isSSHUrl: aString [
 { #category : 'private - patches' }
 IceGitScpRemote >> parseUrl [
 	| urlStream restSegments |
+	
 	(self isSSHUrl: url)
 		ifTrue: [ ^ super parseUrl ].
 	

--- a/Iceberg-Metacello-Integration/IceGitRepositoryType.class.st
+++ b/Iceberg-Metacello-Integration/IceGitRepositoryType.class.st
@@ -20,8 +20,46 @@ IceGitRepositoryType class >> type [
 	^ 'git'
 ]
 
+{ #category : 'private' }
+IceGitRepositoryType >> locationTokens [
+
+	^ self location substrings: ':/'
+]
+
 { #category : 'accessing' }
 IceGitRepositoryType >> mcRepositoryClass [
 	
 	^ MCGitRemoteRepository
+]
+
+{ #category : 'private' }
+IceGitRepositoryType >> projectArgumentPosition [
+
+	^ (self location beginsWith: 'git:http')
+		ifTrue: [ 5 ]
+		ifFalse: [ 4 ]
+]
+
+{ #category : 'accessing' }
+IceGitRepositoryType >> projectName [
+
+	 ^ (self locationTokens at: self projectArgumentPosition) copyUpTo: $.
+]
+
+{ #category : 'accessing' }
+IceGitRepositoryType >> projectVersion [
+	| tokens |
+	
+	tokens := self locationTokens.
+	^ tokens size >= self versionArgumentPosition
+		ifTrue: [ tokens at: self versionArgumentPosition ]
+		ifFalse: [ '' ]
+]
+
+{ #category : 'private' }
+IceGitRepositoryType >> versionArgumentPosition [
+
+	^ (self location beginsWith: 'git:http')
+		ifTrue: [ 6 ]
+		ifFalse: [ 5 ]
 ]

--- a/Iceberg-Metacello-Integration/IceProviderRepositoryType.class.st
+++ b/Iceberg-Metacello-Integration/IceProviderRepositoryType.class.st
@@ -53,14 +53,15 @@ IceProviderRepositoryType >> mcRepository [
 			Because Metacello want to use it"
 		repo forget ].
 
-	baseRepo := self mcRepositoryClass location: self location.
+	baseRepo := self mcRepositoryClass 
+		location: self location 
+		version: (self projectVersion ifEmpty: [ nil ]).
 	^ (Iceberg icebergRepositoriesURLs includes: baseRepo scpUrl)
 		  ifTrue: [ "Do not use Iceberg to load iceberg code, 
 			see https://github.com/pharo-vcs/iceberg/issues/168"
 			  baseRepo ]
 		  ifFalse: [
-			  baseRepo getOrCreateIcebergRepository metacelloAdapter:
-				  self projectVersion ]
+			  baseRepo getOrCreateIcebergRepository metacelloAdapter: self projectVersion ]
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-Metacello-Integration/MCGitRemoteRepository.class.st
+++ b/Iceberg-Metacello-Integration/MCGitRemoteRepository.class.st
@@ -123,7 +123,7 @@ MCGitRemoteRepository >> projectPath [
 { #category : 'accessing' }
 MCGitRemoteRepository >> scpUrl [
 
-	^ '{1}@{2}/{3}.git' format: { 
+	^ '{1}@{2}:{3}.git' format: { 
 		self user. 
 		self host. 
 		self path }

--- a/Iceberg-Metacello-Integration/MCGitRemoteRepository.class.st
+++ b/Iceberg-Metacello-Integration/MCGitRemoteRepository.class.st
@@ -39,6 +39,7 @@ MCGitRemoteRepository class >> parseLocation: aLocation version: aVersion [
 
 	^ self new
 	parseLocation: (aLocation allButFirst: self description size);
+	projectVersion: aVersion;
 	yourself 
 ]
 

--- a/Iceberg-Tests/IceGitRepositoryTypeTest.class.st
+++ b/Iceberg-Tests/IceGitRepositoryTypeTest.class.st
@@ -5,13 +5,13 @@ Class {
 	#package : 'Iceberg-Tests'
 }
 
-{ #category : 'tests' }
+{ #category : 'accessing' }
 IceGitRepositoryTypeTest >> repoHTTPS [
 	
 	^ IceGitRepositoryType location: 'git:https://forge.aplaceinthe.eu/estebanlm/ASuperProject.git:main'
 ]
 
-{ #category : 'tests' }
+{ #category : 'accessing' }
 IceGitRepositoryTypeTest >> repoSSH [
 	
 	^ IceGitRepositoryType location: 'git:git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git:main'

--- a/Iceberg-Tests/IceGitRepositoryTypeTest.class.st
+++ b/Iceberg-Tests/IceGitRepositoryTypeTest.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : 'IceGitRepositoryTypeTest',
+	#superclass : 'TestCase',
+	#category : 'Iceberg-Tests',
+	#package : 'Iceberg-Tests'
+}
+
+{ #category : 'tests' }
+IceGitRepositoryTypeTest >> repoHTTPS [
+	
+	^ IceGitRepositoryType location: 'git:https://forge.aplaceinthe.eu/estebanlm/ASuperProject.git:main'
+]
+
+{ #category : 'tests' }
+IceGitRepositoryTypeTest >> repoSSH [
+	
+	^ IceGitRepositoryType location: 'git:git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git:main'
+]
+
+{ #category : 'tests' }
+IceGitRepositoryTypeTest >> testProjectNameIfHTTPSForm [
+	| type |
+
+	type := self repoHTTPS.
+	self assert: type projectName equals: 'ASuperProject'
+]
+
+{ #category : 'tests' }
+IceGitRepositoryTypeTest >> testProjectNameIfSSHForm [
+	| type |
+	
+	type := self repoSSH.
+	self assert: type projectName equals: 'ASuperProject'
+]
+
+{ #category : 'tests' }
+IceGitRepositoryTypeTest >> testProjectVersionIfHTTPSForm [
+	| type |
+
+	type := self repoHTTPS.
+	self assert: type projectVersion equals: 'main'
+]
+
+{ #category : 'tests' }
+IceGitRepositoryTypeTest >> testProjectVersionIfSSHForm [
+	| type |
+
+	type := self repoSSH.
+	self assert: type projectVersion equals: 'main'
+]

--- a/Iceberg-Tests/MCGitRemoteRepositoryTest.class.st
+++ b/Iceberg-Tests/MCGitRemoteRepositoryTest.class.st
@@ -1,0 +1,61 @@
+Class {
+	#name : 'MCGitRemoteRepositoryTest',
+	#superclass : 'TestCase',
+	#category : 'Iceberg-Tests',
+	#package : 'Iceberg-Tests'
+}
+
+{ #category : 'tests' }
+MCGitRemoteRepositoryTest >> testSSHRepoWithBranch [
+	| repo remoteRepo |
+	
+	repo := IceGitRepositoryType location: 'git:git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git:main'.
+	remoteRepo := MCGitRemoteRepository 
+		location: repo location 
+		version: repo projectVersion.
+		
+	self assert: remoteRepo scpUrl equals: 'git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git'.
+	self assert: remoteRepo projectVersion equals: 'main'
+]
+
+{ #category : 'tests' }
+MCGitRemoteRepositoryTest >> testSSHRepoWithCommitish [
+	| repo remoteRepo |
+	
+	repo := IceGitRepositoryType location: 'git:git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git:a05016fbcdb465e819a1e04aba4943b993b3e835'.
+	remoteRepo := MCGitRemoteRepository 
+		location: repo location 
+		version: repo projectVersion.
+		
+	self assert: remoteRepo scpUrl equals: 'git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git'.
+	self assert: remoteRepo projectVersion equals: 'a05016fbcdb465e819a1e04aba4943b993b3e835'
+]
+
+{ #category : 'tests' }
+MCGitRemoteRepositoryTest >> testSSHRepoWithTag [
+	| repo remoteRepo |
+	
+	repo := IceGitRepositoryType location: 'git:git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git:v1.0.0'.
+	remoteRepo := MCGitRemoteRepository 
+		location: repo location 
+		version: repo projectVersion.
+		
+	self assert: remoteRepo scpUrl equals: 'git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git'.
+	self assert: remoteRepo projectVersion equals: 'v1.0.0'
+]
+
+{ #category : 'tests' }
+MCGitRemoteRepositoryTest >> testSSHRepoWithoutVersion [
+	| repo remoteRepo |
+	
+	self flag: #TODO. "This is how it was working before, but I do not think there should be a 
+	default branch anymore..."
+	
+	repo := IceGitRepositoryType location: 'git:git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git'.
+	remoteRepo := MCGitRemoteRepository 
+		location: repo location 
+		version: repo projectVersion.
+		
+	self assert: remoteRepo scpUrl equals: 'git@forge.aplaceinthe.eu:estebanlm/ASuperProject.git'.
+	self assert: remoteRepo projectVersion equals: 'master'
+]

--- a/Iceberg-TipUI/IceRepository.extension.st
+++ b/Iceberg-TipUI/IceRepository.extension.st
@@ -1,10 +1,11 @@
 Extension { #name : 'IceRepository' }
 
 { #category : '*Iceberg-TipUI' }
-IceRepository >> inspectorItems [
+IceRepository >> inspectorItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Packages'>
 
-	^ SpTablePresenter new
+	^ aBuilder newTable 
+		addStyle: 'stList';
 		beResizable;
 		items: self workingCopy packages;
 		addColumn: (SpStringTableColumn new


### PR DESCRIPTION
while iceberg has always be capable of clone an arbitrary git repository (providing it has the right .git url), metacello, even meracello-iceberg-integration was not able to do it... thee was a mechanism implemented but it was broken. 

This PR fixes that (or tries :P).

Now you are capable of cloning a repository using this way: 

```smalltalk
Metacello new 
	baseline: 'CIG';
	repository: 'git:git@github.com:estebanlm/pharo-cig.git:main';
	load.
```

means, repository url is : 
1. `git:`  the  identifier.
2. `git@github.com:estebanlm/pharo-cig.git`  a git url like the ones provided by any git server nowadays. 
3. `:main` a branch

of course, this is providing that you have metacello-iceberg-integration enabled... which is the case in any pharo image nowadays) 