### PR TITLE
Update version in #libgit: for BaselineOfIceberg for Pharo 13 to ‘v3.2.1’

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -80,7 +80,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.2.0';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.2.1';
   				loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'


### PR DESCRIPTION
This pull request updates the version in #libgit: for BaselineOfIceberg for Pharo 13 to ‘v3.2.1’.

Before merging this please:
* Merge [libgit2-pharo-bindings pull request #100](https://github.com/pharo-vcs/libgit2-pharo-bindings/pull/100)
* Tag the resulting ‘Pharo13’ commit in libgit2-pharo-bindings as ‘v3.2.1’