### PR TITLE
Update version in #libgit: for BaselineOfIceberg for Pharo 12 to ‘v3.1.3’

### DIFF
--- a/BaselineOfIceberg/BaselineOfIceberg.class.st
+++ b/BaselineOfIceberg/BaselineOfIceberg.class.st
@@ -76,7 +76,7 @@ BaselineOfIceberg >> libgit: spec [
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.1.2';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v3.1.3';
   			loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'


### PR DESCRIPTION
This pull request updates the version in #libgit: for BaselineOfIceberg for Pharo 12 to ‘v3.1.3’.

Before merging this please:
* Merge [libgit2-pharo-bindings pull request #101](https://github.com/pharo-vcs/libgit2-pharo-bindings/pull/101)
* Tag the resulting ‘Pharo12’ commit in libgit2-pharo-bindings as ‘v3.1.3’