### PR TITLE
'Import from existing clone' exception handled by dialog

### DIFF
--- a/Iceberg-TipUI/IceTipDirectoryPresenter.class.st
+++ b/Iceberg-TipUI/IceTipDirectoryPresenter.class.st
@@ -14,7 +14,10 @@ IceTipDirectoryPresenter >> chooseReference [
 
 	| reference |
 	StOpenDirectoryPresenter new
-		openFolder: (self location ifNil: [ FileLocator workingDirectory ]);
+		openFolder:
+			((self location ifNil: [ FileLocator workingDirectory ]) exists
+				 ifTrue: [ self location ifNil: [ FileLocator workingDirectory ] ]
+				 ifFalse: [ FileLocator imageDirectory parent ]);
 		title: self chooseTitle;
 		okAction: [ :directoryReference | reference := directoryReference ];
 		openModal.


### PR DESCRIPTION
Entering a wrong path was raising an exception, which we don't want for the user. This is why in case this happens the dialog opens by default in the images directory, letting the user choose a repository to clone locally in other images (if he made a mistake or just typed random text ).
Fixes https://github.com/pharo-project/pharo/issues/18386