### PR TITLE
Using existing locations as default ones and tests

### DIFF
--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -97,7 +97,7 @@ IceLibgitRepository class >> libgitRepositoryHandleAccessors [
 { #category : 'accessing' }
 IceLibgitRepository class >> localRepositoriesLocation [
 
-	^ FileLocator localDirectory
+	^ (FileLocator localDirectory / 'iceberg') ensureCreateDirectory
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -96,14 +96,16 @@ IceLibgitRepository class >> libgitRepositoryHandleAccessors [
 
 { #category : 'accessing' }
 IceLibgitRepository class >> localRepositoriesLocation [
-	^ FileLocator localDirectory / #iceberg
+
+	^ FileLocator localDirectory
 ]
 
 { #category : 'accessing' }
 IceLibgitRepository class >> repositoriesLocation [
- 	^ self shareRepositoriesBetweenImages 
-		ifTrue: [ self sharedRepositoriesLocation ]
-		ifFalse: [ self localRepositoriesLocation ] 
+
+	^ self shareRepositoriesBetweenImages
+		  ifTrue: [ self sharedRepositoriesLocation ]
+		  ifFalse: [ self localRepositoriesLocation ]
 ]
 
 { #category : 'utilities' }
@@ -162,8 +164,9 @@ IceLibgitRepository class >> shareRepositoriesBetweenImages: anObject [
 
 { #category : 'settings' }
 IceLibgitRepository class >> sharedRepositoriesLocation [
-	^ SharedRepositoriesLocation ifNil: [ 
-		SharedRepositoriesLocation := (FileLocator home / #iceberg) asFileReference ]
+
+	^ SharedRepositoriesLocation ifNil: [
+		  SharedRepositoriesLocation := FileLocator home asFileReference ]
 ]
 
 { #category : 'settings' }

--- a/Iceberg-Tests/IceLibgitRepositoryTest.class.st
+++ b/Iceberg-Tests/IceLibgitRepositoryTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'IceLibgitRepositoryTest',
+	#superclass : 'TestCase',
+	#category : 'Iceberg-Tests',
+	#package : 'Iceberg-Tests'
+}
+
+{ #category : 'tests' }
+IceLibgitRepositoryTest >> testLocalRepositoriesLocation [
+
+	self assert: IceLibgitRepository localRepositoriesLocation exists
+]
+
+{ #category : 'tests' }
+IceLibgitRepositoryTest >> testSharedRepositoriesLocation [
+
+	self assert: IceLibgitRepository sharedRepositoriesLocation exists
+]


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/18319

(First see issue's description)

This PR changes the default locations from selecting the repositories to a location that will **always** exists.
For example, before this PR, the repositoriesLocation tried to open the iceberg folder inside the Pharo image. BUT; this folder only exists in someone already cloned a repo in the same image. In a fresh image, this will fail with an exception as described in the issue.

It also adds two tests