### PR TITLE
Changig when to show write to files command.

### DIFF
--- a/Iceberg-TipUI/IceTipWriteToFilesCommand.class.st
+++ b/Iceberg-TipUI/IceTipWriteToFilesCommand.class.st
@@ -24,7 +24,7 @@ IceTipWriteToFilesCommand class >> defaultName [
 { #category : 'testing' }
 IceTipWriteToFilesCommand >> canBeExecuted [
 
-	^ self isRepositoryOperational
+	^ self repositoryModel isNotNil and: [ self isRepositoryMissing not ]
 ]
 
 { #category : 'executing' }


### PR DESCRIPTION
The command write to files can be executed even if the repo is out of sync. Actually, this is were it comes useful. 