### PR TITLE
Add an option to group opened repositories in Iceberg

### DIFF
--- a/Iceberg-TipUI/IceTipManagePackagesCommand.class.st
+++ b/Iceberg-TipUI/IceTipManagePackagesCommand.class.st
@@ -1,9 +1,14 @@
 "
 I'm a command to open the package manager browser for a project.
+
+I have an option to group the windows I'm opening into one group windows.
 "
 Class {
 	#name : 'IceTipManagePackagesCommand',
 	#superclass : 'IceTipRepositoryCommand',
+	#classVars : [
+		'ShouldGroupRepositories'
+	],
 	#category : 'Iceberg-TipUI-Commands',
 	#package : 'Iceberg-TipUI',
 	#tag : 'Commands'
@@ -21,13 +26,51 @@ IceTipManagePackagesCommand class >> defaultName [
 	^ 'Packages'
 ]
 
+{ #category : 'settings' }
+IceTipManagePackagesCommand class >> settingsOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder setting: #shouldGroupRepositories)
+		parent: #Iceberg;
+		target: self;
+		label: 'Group repositories in a group window';
+		description: 'If this settings get enabled, the repositories you will open will be grouped in the same window.'
+]
+
+{ #category : 'asserting' }
+IceTipManagePackagesCommand class >> shouldGroupRepositories [
+
+	^ ShouldGroupRepositories ifNil: [ ShouldGroupRepositories := true ]
+]
+
+{ #category : 'asserting' }
+IceTipManagePackagesCommand class >> shouldGroupRepositories: aBoolean [
+
+	ShouldGroupRepositories := aBoolean
+]
+
 { #category : 'executing' }
 IceTipManagePackagesCommand >> execute [
 
-	(IceTipWorkingCopyBrowser 
-		newApplication: context application 
-		model: self repositoryModel workingCopyModel) 
-		open
+	| browser group |
+	browser := (IceTipWorkingCopyBrowser newApplication: context application model: self repositoryModel workingCopyModel) open.
+
+	self class shouldGroupRepositories ifFalse: [ ^ self ].
+
+	group := (self currentWorld windowsSatisfying: [ :window | window label = 'Iceberg Repositories' ])
+		         ifEmpty: [
+				         | window |
+				         window := GroupWindowMorph new.
+				         (window openInWindowLabeled: 'Iceberg Repositories') extent: 1200 @ 800.
+				         window ]
+		         ifNotEmpty: [ :ws |
+				         | window |
+				         window := ws first.
+				         window isMinimized
+					         ifTrue: [ window restore ]
+					         ifFalse: [ window activate ].
+				         window paneMorphs first ].
+	group addWindow: browser window
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
With this option, when you open a repository, it will open a group window and put future repositories there instead of creating one window by project

Example:
<img width="1214" height="811" alt="image" src="https://github.com/user-attachments/assets/4087e392-bf25-4c64-8e22-acf4fe963550" />

This option can be disabled in the settings