### PR TITLE
Drop "Working copy of" from the name of IceTipWorkingCopyBrowser

### DIFF
--- a/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
+++ b/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
@@ -271,7 +271,7 @@ IceTipWorkingCopyBrowser >> updatePresenter [
 { #category : 'initialization' }
 IceTipWorkingCopyBrowser >> windowTitle [
 
-	^ 'Working copy of ', self model repositoryName
+	^ self model repositoryName
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This is an implementation detail to know that we are working on a working copy. This make is harder to find the right Iceberg windows in the docking bar at the bottom of Pharo because they all start by "Working copy" and the rest of the title is cut.