### PR TITLE
Add IceTipRepositoriesBrowser class>>ensureOpen

### DIFF
--- a/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
@@ -68,6 +68,20 @@ IceTipRepositoriesBrowser class >> defaultPreferredExtent [
 	^ (600 @ 500)
 ]
 
+{ #category : 'as yet unclassified' }
+IceTipRepositoriesBrowser class >> ensureIsOpen [
+
+	<script>
+	(self currentWorld windowsSatisfying: [ :window | (window isKindOf: SpWindowMorph) and: [ window model presenter isKindOf: self ] ])
+		ifEmpty: [ self new open ]
+		ifNotEmpty: [ :windows |
+				| window |
+				window := windows anyOne.
+				window isMinimized
+					ifTrue: [ window restore ]
+					ifFalse: [ window activate ] ]
+]
+
 { #category : 'accessing' }
 IceTipRepositoriesBrowser class >> iconForWorldMenu [
 

--- a/Iceberg-TipUI/ToolShortcutsCategory.extension.st
+++ b/Iceberg-TipUI/ToolShortcutsCategory.extension.st
@@ -4,7 +4,5 @@ Extension { #name : 'ToolShortcutsCategory' }
 ToolShortcutsCategory >> openIceberg [
 
 	<shortcut>
-	^ KMKeymap
-		  shortcut: PharoShortcuts current openIcebergShortcut
-		  action: [ IceTipRepositoriesBrowser new open ]
+	^ KMKeymap shortcut: PharoShortcuts current openIcebergShortcut action: [ IceTipRepositoriesBrowser ensureOpen ]
 ]


### PR DESCRIPTION
Add a method to ensure Iceberg is open. In case it is, bring it to the front. Else, open a new one.

The goal is to use this method in Pharo to avoid reopening multiple times the same window.