### PR TITLE
Changing tabs when editing metadata project

### DIFF
--- a/.project
+++ b/.project
@@ -1,4 +1,6 @@
 {
 	'srcDirectory' : '',
-	'tags' : [ #system ]
+	'tags' : [
+		'projects'
+	]
 }

--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -16,7 +16,9 @@ Class {
 		'messageIcon',
 		'messageText',
 		'removeButton',
-		'addButton'
+		'addButton',
+		'tabLabel',
+		'tabList'
 	],
 	#category : 'Iceberg-TipUI-View-Repository',
 	#package : 'Iceberg-TipUI',
@@ -91,8 +93,12 @@ IceTipEditProjectDialogPresenter >> connectPresenters [
 		display: [ :each | each description ];
 		selectItem: (self guessFormatFromDirectory: model sourceDirectoryReference).
 
-	self expandAndSelect: (RelativePath with: model sourceDirectory).
+	self tabList
+		items: (IceTipRepositoriesBrowser new model repositories collect: [ :each |
+					 each entity project tags ifNotEmpty: [ :tags | tags first asString capitalized ] ifEmpty: [ '' ] ]) asSet asArray;
+		display: [ :each | each ].
 
+	self expandAndSelect: (RelativePath with: model sourceDirectory)
 ]
 
 { #category : 'accessing' }
@@ -105,35 +111,42 @@ IceTipEditProjectDialogPresenter >> defaultFormat [
 IceTipEditProjectDialogPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		borderWidth: 5;
-		spacing: 5;
-		add: (SpBoxLayout newLeftToRight
-				spacing: 5;
-				vAlignCenter;
-				add: nameLabel expand: false;
-				add: nameInput;
-				add: addButton expand: false;
-				add: removeButton expand: false;
-				yourself)
-		  	expand: false;
-		add: (SpBoxLayout newLeftToRight
-				spacing: 5;
-				add: sourceDirectoryLabel expand: false;
-				add: sourceDirectoryTree;
-				yourself);
-		add: (SpBoxLayout newLeftToRight
-				vAlignCenter;
-				spacing: 5;
-				add: formatLabel expand: false;
-				add: formatList;
-				yourself)
-			expand: false;
-		add: (SpBoxLayout newLeftToRight
-				spacing: 5;
-				add: messageIcon expand: false;
-				add: messageText;
-				yourself);
-		yourself
+		  borderWidth: 5;
+		  spacing: 5;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: 5;
+				   vAlignCenter;
+				   add: nameLabel expand: false;
+				   add: nameInput;
+				   add: addButton expand: false;
+				   add: removeButton expand: false;
+				   yourself)
+		  expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: 5;
+				   add: sourceDirectoryLabel expand: false;
+				   add: sourceDirectoryTree;
+				   yourself);
+		  add: (SpBoxLayout newLeftToRight
+				   vAlignCenter;
+				   spacing: 5;
+				   add: formatLabel expand: false;
+				   add: formatList;
+				   yourself)
+		  expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   vAlignCenter;
+				   spacing: 5;
+				   add: tabLabel expand: false;
+				   add: tabList;
+				   yourself)
+		  expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: 5;
+				   add: messageIcon expand: false;
+				   add: messageText;
+				   yourself);
+		  yourself
 ]
 
 { #category : 'utilities' }
@@ -253,35 +266,39 @@ IceTipEditProjectDialogPresenter >> initializeMessagePanel [
 IceTipEditProjectDialogPresenter >> initializePresenters [
 
 	nameLabel := self newLabel
-		label: 'Project Name';
-		yourself.
+		             label: 'Project Name';
+		             yourself.
 	nameInput := self newLabel
-		label: self model name;
-		yourself.
+		             label: self model name;
+		             yourself.
 	sourceDirectoryLabel := self newLabel
-		label: 'Code directory';
-		yourself.
+		                        label: 'Code directory';
+		                        yourself.
 	sourceDirectoryTree := self newTreeTable
-		hideColumnHeaders;
-		yourself.
+		                       hideColumnHeaders;
+		                       yourself.
 	formatLabel := self newLabel
-		label: 'Format';
-		yourself.
+		               label: 'Format';
+		               yourself.
 	formatList := self newDropList.
+	tabLabel := self newLabel
+		            label: 'Tabs';
+		            yourself.
+	tabList := self newDropList.
 	messageIcon := self newImage.
 	messageText := self newText
-		beNotEditable;
-		addStyle: 'iceTipReadonly';
-		yourself.
+		               beNotEditable;
+		               addStyle: 'iceTipReadonly';
+		               yourself.
 
-	removeButton := self newButton 
-		addStyle: 'small';
-		icon: (self iconNamed: #remove); 
-		yourself.
-	addButton := self newButton 
-		addStyle: 'small';
-		icon: (self iconNamed: #add); 
-		yourself.
+	removeButton := self newButton
+		                addStyle: 'small';
+		                icon: (self iconNamed: #remove);
+		                yourself.
+	addButton := self newButton
+		             addStyle: 'small';
+		             icon: (self iconNamed: #add);
+		             yourself.
 
 	self initializeMessagePanel.
 	self initializeDirectoryTree
@@ -385,6 +402,12 @@ IceTipEditProjectDialogPresenter >> sourceDirectorySelectionChanged: selectedPat
 IceTipEditProjectDialogPresenter >> sourceDirectoryTree [
 
 	^ sourceDirectoryTree
+]
+
+{ #category : 'accessing' }
+IceTipEditProjectDialogPresenter >> tabList [
+
+	^ tabList
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -34,23 +34,22 @@ IceTipEditProjectDialogPresenter class >> defaultPreferredExtent [
 { #category : 'actions' }
 IceTipEditProjectDialogPresenter >> accept [
 
+	| newTagValue |
+	newTagValue := self tabList selectedItem group ifEmpty: [ 'projects' ] ifNotEmpty: [ :group | group ].
+	model repository project properties at: #tags put: { newTagValue }.
 	IceTipStandardAction new
 		repository: model repository;
 		message: 'Setting up project';
 		onSuccessRepositoryModified;
-		action: [
-			"Update the project"
-			model sourceDirectory: self selectedDirectoryPath pathString.
-			model fileFormat: self selectedFileFormat.
-			(model repositoryProperties fileFormat = self selectedFileFormat)
-				ifFalse: [ self error: 'Selected file format is incorrect.' ].
-			"Set the project in the repository"
-			model repository workingCopy project: model ];
+		action: [ "Update the project"
+				model sourceDirectory: self selectedDirectoryPath pathString.
+				model fileFormat: self selectedFileFormat.
+				model repositoryProperties fileFormat = self selectedFileFormat ifFalse: [ self error: 'Selected file format is incorrect.' ]. "Set the project in the repository"
+				model repository workingCopy project: model ];
 		executeWithContext: self.
 
 	self closeWindow.
-	acceptCallback ifNotNil: [
-		acceptCallback value ]
+	acceptCallback ifNotNil: [ acceptCallback value ]
 ]
 
 { #category : 'accessing' }
@@ -94,9 +93,8 @@ IceTipEditProjectDialogPresenter >> connectPresenters [
 		selectItem: (self guessFormatFromDirectory: model sourceDirectoryReference).
 
 	self tabList
-		items: (IceTipRepositoriesBrowser new model repositories collect: [ :each |
-					 each entity project tags ifNotEmpty: [ :tags | tags first asString capitalized ] ifEmpty: [ '' ] ]) asSet asArray;
-		display: [ :each | each ].
+		items: IceTipRepositoriesBrowser new model repositoryGroups asSet asArray;
+		display: [ :each | each group capitalized ifEmpty: 'Projects' ].
 
 	self expandAndSelect: (RelativePath with: model sourceDirectory)
 ]

--- a/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
@@ -93,7 +93,7 @@ IceTipGitProviderRepositoryPanel >> projectAsPathToAppend [
 { #category : 'accessing' }
 IceTipGitProviderRepositoryPanel >> projectName [
 
-	^ self projectNameInputText text asString trimmed
+	^ self projectNameInputText text asString trimBoth
 ]
 
 { #category : 'accessing - ui' }
@@ -146,7 +146,7 @@ IceTipGitProviderRepositoryPanel >> selectedProtocol [
 { #category : 'accessing' }
 IceTipGitProviderRepositoryPanel >> userName [
 
-	^ self userNameInputText text asString trimmed
+	^ self userNameInputText text asString trimBoth
 ]
 
 { #category : 'accessing - ui' }

--- a/Iceberg-TipUI/IceTipRepositoriesModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesModel.class.st
@@ -54,7 +54,7 @@ IceTipRepositoriesModel >> repositoryGroups [
 		See class side"
 	groups := groups sorted:
 		          [ :each | self class sortGroup at: each ifAbsent: [ 1 ] ] ascending , [ :each | each yourself ] ascending. "add default group first if it is not there yet."
-	(groups isEmpty or: [ groups first = '' ]) ifFalse: [ groups := groups copyWithFirst: '' ].
+	(groups isEmpty or: [ groups first = '' ]) ifFalse: [ groups := groups copyWithFirst: '' ]. 
 
 	^ groups collect: [ :each |
 			  IceTipRepositoryGroupModel new

--- a/Iceberg-TipUI/IceTipRepositoriesModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesModel.class.st
@@ -42,33 +42,24 @@ IceTipRepositoriesModel >> repositories [
 
 { #category : 'accessing' }
 IceTipRepositoriesModel >> repositoryGroups [
+
 	| groups |
-
 	groups := self repositories
-		collect: [ :each |
-			each entity project tags
-				ifNotEmpty: [ :tags | tags first asString ]
-				ifEmpty: [ '' ] ]
-		as: Set.
-
-	"sort groups:
+		          collect: [ :each | each entity project tags ifNotEmpty: [ :tags | tags first asString ] ifEmpty: [ '' ] ]
+		          as: Set. "sort groups:
 		1. user defined groups with a defined priority (<0) sorted by priority
 	 	2. 'general' group (all projects without a group tag).
 		3. user defined groups without defined priority, sorted alphabetically
 		4. last (always last) system group
 		See class side"
 	groups := groups sorted:
-		[ :each | self class sortGroup at: each ifAbsent: [ 1 ] ] ascending,
-		[ :each | each yourself ] ascending.
-
-	"add default group first if it is not there yet."
-	(groups isEmpty or: [ groups first = ''])
-		ifFalse: [ groups := groups copyWithFirst: '' ].
+		          [ :each | self class sortGroup at: each ifAbsent: [ 1 ] ] ascending , [ :each | each yourself ] ascending. "add default group first if it is not there yet."
+	(groups isEmpty or: [ groups first = '' ]) ifFalse: [ groups := groups copyWithFirst: '' ].
 
 	^ groups collect: [ :each |
-		IceTipRepositoryGroupModel new
-			repositoryProvider: repositoryProvider;
-			group: each ]
+			  IceTipRepositoryGroupModel new
+				  repositoryProvider: repositoryProvider;
+				  group: each ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
With these changes;
- The user can switch any metadata project in the repository group he wants in the ```Repositories``` presenter
- Allows to have a better organization in repositories
- Fixes https://github.com/pharo-vcs/iceberg/issues/1964