### PR TITLE
Changing tabs when editing metadata project

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 {
 	'srcDirectory' : '',
 	'tags' : [
-		'tools'
+		#system
 	]
 }

--- a/.project
+++ b/.project
@@ -1,4 +1,6 @@
 {
 	'srcDirectory' : '',
-	'tags' : [ #system ]
+	'tags' : [
+		'tools'
+	]
 }

--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -16,7 +16,9 @@ Class {
 		'messageIcon',
 		'messageText',
 		'removeButton',
-		'addButton'
+		'addButton',
+		'tabLabel',
+		'tabList'
 	],
 	#category : 'Iceberg-TipUI-View-Repository',
 	#package : 'Iceberg-TipUI',
@@ -32,23 +34,22 @@ IceTipEditProjectDialogPresenter class >> defaultPreferredExtent [
 { #category : 'actions' }
 IceTipEditProjectDialogPresenter >> accept [
 
+	| newTagValue |
+	newTagValue := self tabList selectedItem group ifEmpty: [ 'projects' ] ifNotEmpty: [ :group | group ].
+	model repository project properties at: #tags put: { newTagValue }.
 	IceTipStandardAction new
 		repository: model repository;
 		message: 'Setting up project';
-		onSuccessRepositoryModified;
-		action: [
-			"Update the project"
-			model sourceDirectory: self selectedDirectoryPath pathString.
-			model fileFormat: self selectedFileFormat.
-			(model repositoryProperties fileFormat = self selectedFileFormat)
-				ifFalse: [ self error: 'Selected file format is incorrect.' ].
-			"Set the project in the repository"
-			model repository workingCopy project: model ];
+		onSuccessRepositoryModified; 
+		action: [ "Update the project"
+				model sourceDirectory: self selectedDirectoryPath pathString.
+				model fileFormat: self selectedFileFormat.
+				model repositoryProperties fileFormat = self selectedFileFormat ifFalse: [ self error: 'Selected file format is incorrect.' ]. "Set the project in the repository"
+				model repository workingCopy project: model ];
 		executeWithContext: self.
 
 	self closeWindow.
-	acceptCallback ifNotNil: [
-		acceptCallback value ]
+	acceptCallback ifNotNil: [ acceptCallback value ]
 ]
 
 { #category : 'accessing' }
@@ -91,8 +92,11 @@ IceTipEditProjectDialogPresenter >> connectPresenters [
 		display: [ :each | each description ];
 		selectItem: (self guessFormatFromDirectory: model sourceDirectoryReference).
 
-	self expandAndSelect: (RelativePath with: model sourceDirectory).
+	self tabList
+		items: IceTipRepositoriesBrowser new model repositoryGroups asSet asArray;
+		display: [ :each | each group capitalized ifEmpty: 'Projects' ].
 
+	self expandAndSelect: (RelativePath with: model sourceDirectory)
 ]
 
 { #category : 'accessing' }
@@ -105,35 +109,42 @@ IceTipEditProjectDialogPresenter >> defaultFormat [
 IceTipEditProjectDialogPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		borderWidth: 5;
-		spacing: 5;
-		add: (SpBoxLayout newLeftToRight
-				spacing: 5;
-				vAlignCenter;
-				add: nameLabel expand: false;
-				add: nameInput;
-				add: addButton expand: false;
-				add: removeButton expand: false;
-				yourself)
-		  	expand: false;
-		add: (SpBoxLayout newLeftToRight
-				spacing: 5;
-				add: sourceDirectoryLabel expand: false;
-				add: sourceDirectoryTree;
-				yourself);
-		add: (SpBoxLayout newLeftToRight
-				vAlignCenter;
-				spacing: 5;
-				add: formatLabel expand: false;
-				add: formatList;
-				yourself)
-			expand: false;
-		add: (SpBoxLayout newLeftToRight
-				spacing: 5;
-				add: messageIcon expand: false;
-				add: messageText;
-				yourself);
-		yourself
+		  borderWidth: 5;
+		  spacing: 5;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: 5;
+				   vAlignCenter;
+				   add: nameLabel expand: false;
+				   add: nameInput;
+				   add: addButton expand: false;
+				   add: removeButton expand: false;
+				   yourself)
+		  expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: 5;
+				   add: sourceDirectoryLabel expand: false;
+				   add: sourceDirectoryTree;
+				   yourself);
+		  add: (SpBoxLayout newLeftToRight
+				   vAlignCenter;
+				   spacing: 5;
+				   add: formatLabel expand: false;
+				   add: formatList;
+				   yourself)
+		  expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   vAlignCenter;
+				   spacing: 5;
+				   add: tabLabel expand: false;
+				   add: tabList;
+				   yourself)
+		  expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: 5;
+				   add: messageIcon expand: false;
+				   add: messageText;
+				   yourself);
+		  yourself
 ]
 
 { #category : 'utilities' }
@@ -253,35 +264,39 @@ IceTipEditProjectDialogPresenter >> initializeMessagePanel [
 IceTipEditProjectDialogPresenter >> initializePresenters [
 
 	nameLabel := self newLabel
-		label: 'Project Name';
-		yourself.
+		             label: 'Project Name';
+		             yourself.
 	nameInput := self newLabel
-		label: self model name;
-		yourself.
+		             label: self model name;
+		             yourself.
 	sourceDirectoryLabel := self newLabel
-		label: 'Code directory';
-		yourself.
+		                        label: 'Code directory';
+		                        yourself.
 	sourceDirectoryTree := self newTreeTable
-		hideColumnHeaders;
-		yourself.
+		                       hideColumnHeaders;
+		                       yourself.
 	formatLabel := self newLabel
-		label: 'Format';
-		yourself.
+		               label: 'Format';
+		               yourself.
 	formatList := self newDropList.
+	tabLabel := self newLabel 
+		            label: 'Tabs';
+		            yourself.
+	tabList := self newDropList.
 	messageIcon := self newImage.
 	messageText := self newText
-		beNotEditable;
-		addStyle: 'iceTipReadonly';
-		yourself.
+		               beNotEditable;
+		               addStyle: 'iceTipReadonly';
+		               yourself.
 
-	removeButton := self newButton 
-		addStyle: 'small';
-		icon: (self iconNamed: #remove); 
-		yourself.
-	addButton := self newButton 
-		addStyle: 'small';
-		icon: (self iconNamed: #add); 
-		yourself.
+	removeButton := self newButton
+		                addStyle: 'small';
+		                icon: (self iconNamed: #remove);
+		                yourself.
+	addButton := self newButton
+		             addStyle: 'small';
+		             icon: (self iconNamed: #add);
+		             yourself.
 
 	self initializeMessagePanel.
 	self initializeDirectoryTree
@@ -385,6 +400,12 @@ IceTipEditProjectDialogPresenter >> sourceDirectorySelectionChanged: selectedPat
 IceTipEditProjectDialogPresenter >> sourceDirectoryTree [
 
 	^ sourceDirectoryTree
+]
+
+{ #category : 'accessing' }
+IceTipEditProjectDialogPresenter >> tabList [
+
+	^ tabList
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -2,22 +2,18 @@ Class {
 	#name : 'IceTipEditProjectDialogPresenter',
 	#superclass : 'IceTipDialogPresenter',
 	#instVars : [
-		'nameLabel',
 		'nameInput',
 		'model',
 		'acceptCallback',
-		'sourceDirectoryLabel',
 		'sourceDirectoryTree',
 		'selectedDirectoryPath',
 		'formatList',
-		'formatLabel',
 		'formats',
 		'defaultFormat',
 		'messageIcon',
 		'messageText',
 		'removeButton',
 		'addButton',
-		'tabLabel',
 		'tabList'
 	],
 	#category : 'Iceberg-TipUI-View-Repository',
@@ -114,7 +110,7 @@ IceTipEditProjectDialogPresenter >> defaultLayout [
 		  add: (SpBoxLayout newLeftToRight
 				   spacing: 5;
 				   vAlignCenter;
-				   add: nameLabel expand: false;
+				   add: 'Project name' expand: false;
 				   add: nameInput;
 				   add: addButton expand: false;
 				   add: removeButton expand: false;
@@ -122,20 +118,20 @@ IceTipEditProjectDialogPresenter >> defaultLayout [
 		  expand: false;
 		  add: (SpBoxLayout newLeftToRight
 				   spacing: 5;
-				   add: sourceDirectoryLabel expand: false;
+				   add: 'Code directory' expand: false;
 				   add: sourceDirectoryTree;
 				   yourself);
 		  add: (SpBoxLayout newLeftToRight
 				   vAlignCenter;
 				   spacing: 5;
-				   add: formatLabel expand: false;
+				   add: 'Format' expand: false;
 				   add: formatList;
 				   yourself)
 		  expand: false;
 		  add: (SpBoxLayout newLeftToRight
 				   vAlignCenter;
 				   spacing: 5;
-				   add: tabLabel expand: false;
+				   add: 'Group' expand: false;
 				   add: tabList;
 				   yourself)
 		  expand: false;
@@ -172,12 +168,6 @@ IceTipEditProjectDialogPresenter >> expandAndSelect: aRelativePath [
 	
 
 
-]
-
-{ #category : 'accessing - ui' }
-IceTipEditProjectDialogPresenter >> formatLabel [
-
-	^ formatLabel
 ]
 
 { #category : 'accessing - ui' }
@@ -263,25 +253,13 @@ IceTipEditProjectDialogPresenter >> initializeMessagePanel [
 { #category : 'initialization' }
 IceTipEditProjectDialogPresenter >> initializePresenters [
 
-	nameLabel := self newLabel
-		             label: 'Project Name';
-		             yourself.
 	nameInput := self newLabel
 		             label: self model name;
 		             yourself.
-	sourceDirectoryLabel := self newLabel
-		                        label: 'Code directory';
-		                        yourself.
 	sourceDirectoryTree := self newTreeTable
 		                       hideColumnHeaders;
 		                       yourself.
-	formatLabel := self newLabel
-		               label: 'Format';
-		               yourself.
 	formatList := self newDropList.
-	tabLabel := self newLabel 
-		            label: 'Tabs';
-		            yourself.
 	tabList := self newDropList.
 	messageIcon := self newImage.
 	messageText := self newText
@@ -326,12 +304,6 @@ IceTipEditProjectDialogPresenter >> nameInput [
 	^ nameInput
 ]
 
-{ #category : 'accessing - ui' }
-IceTipEditProjectDialogPresenter >> nameLabel [
-
-	^ nameLabel
-]
-
 { #category : 'events' }
 IceTipEditProjectDialogPresenter >> onAccept: aBlockClosure [ 
 	
@@ -372,12 +344,6 @@ IceTipEditProjectDialogPresenter >> selectedFileFormat [
 IceTipEditProjectDialogPresenter >> setModelBeforeInitialization: anObject [
 
 	model := anObject
-]
-
-{ #category : 'accessing - ui' }
-IceTipEditProjectDialogPresenter >> sourceDirectoryLabel [
-
-	^ sourceDirectoryLabel
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -14,7 +14,8 @@ Class {
 		'messageText',
 		'removeButton',
 		'addButton',
-		'tabList'
+		'tabList',
+		'addTabButton'
 	],
 	#category : 'Iceberg-TipUI-View-Repository',
 	#package : 'Iceberg-TipUI',
@@ -78,10 +79,22 @@ IceTipEditProjectDialogPresenter >> addDirectory [
 { #category : 'initialization' }
 IceTipEditProjectDialogPresenter >> connectPresenters [
 
+	| presenter |
 	super connectPresenters.
 
 	removeButton action: [ self removeDirectory ].
 	addButton action: [ self addDirectory ].
+	addTabButton action: [
+			presenter := SpRequestDialog new
+				             title: 'Add new repository group';
+				             label: 'What is the name of your group?';
+				             text: '';
+				             acceptLabel: 'Confirm';
+				             cancelLabel: 'Cancel';
+				             onAccept: [ :dialog | model repository project properties at: #tags put: { dialog presenter text asSymbol } ];
+				             openDialog.
+			self closeWindow.
+			acceptCallback ifNotNil: [ acceptCallback value ] ].
 
 	self formatList
 		items: self formats;
@@ -133,6 +146,7 @@ IceTipEditProjectDialogPresenter >> defaultLayout [
 				   spacing: 5;
 				   add: 'Group' expand: false;
 				   add: tabList;
+				   add: addTabButton expand: false;
 				   yourself)
 		  expand: false;
 		  add: (SpBoxLayout newLeftToRight
@@ -275,7 +289,10 @@ IceTipEditProjectDialogPresenter >> initializePresenters [
 		             addStyle: 'small';
 		             icon: (self iconNamed: #add);
 		             yourself.
-
+	addTabButton := self newButton
+		                addStyle: 'small';
+		                icon: (self iconNamed: #add);
+		                yourself.
 	self initializeMessagePanel.
 	self initializeDirectoryTree
 ]

--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -36,11 +36,11 @@ IceTipEditProjectDialogPresenter >> accept [
 
 	| newTagValue |
 	newTagValue := self tabList selectedItem group ifEmpty: [ 'projects' ] ifNotEmpty: [ :group | group ].
-	model repository project properties at: #tags put: { newTagValue }.
+	model repository project properties at: #tags put: { newTagValue asSymbol }.
 	IceTipStandardAction new
 		repository: model repository;
 		message: 'Setting up project';
-		onSuccessRepositoryModified; 
+		onSuccessRepositoryModified;
 		action: [ "Update the project"
 				model sourceDirectory: self selectedDirectoryPath pathString.
 				model fileFormat: self selectedFileFormat.


### PR DESCRIPTION
With these changes;
- The user can switch any metadata project in the repository group he wants in the ```Repositories``` presenter
- Allows to have a better organization in repositories
- Fixes #1964