### PR TITLE
Change ```IceTipDirectoryPresenter``` location condition

### DIFF
--- a/Iceberg-TipUI/IceTipDirectoryPresenter.class.st
+++ b/Iceberg-TipUI/IceTipDirectoryPresenter.class.st
@@ -14,7 +14,7 @@ IceTipDirectoryPresenter >> chooseReference [
 
 	| reference |
 	StOpenDirectoryPresenter new
-		openFolder: (self location ifNil: [ FileLocator workingDirectory ]);
+		openFolder: (self location exists ifFalse: [ FileLocator workingDirectory ]);
 		title: self chooseTitle;
 		okAction: [ :directoryReference | reference := directoryReference ];
 		openModal.


### PR DESCRIPTION
To prevent an error while wanting to modify the path directly before opening the presenter, if the location doesn't exist it will open on a default location
Fixes https://github.com/pharo-project/pharo/issues/18539#event-19685907808