### PR TITLE
Enable / disbale commit button while commiting something

### DIFF
--- a/Iceberg-TipUI/IceTipCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCommitBrowser.class.st
@@ -110,13 +110,13 @@ IceTipCommitBrowser >> doCommit [
 	message := commentPanel message.
 	isPushing := commentPanel isPushing.
 	isSaving := commentPanel isSaving.
-
+	commentPanel commitButton enabled: false.
 	commitBlock := [
-		self
-			doCommit: selectedItems
-		 	message: message
-		  	pushing: isPushing
-		   	saving: isSaving ].
+		               self
+			               doCommit: selectedItems
+			               message: message
+			               pushing: isPushing
+			               saving: isSaving ].
 
 	(IceTipCritiquesBeforeCommitBrowser
 		 onApplication: self application
@@ -132,13 +132,12 @@ IceTipCommitBrowser >> doCommit: aCollection message: aString pushing: pushingBo
 		diff: self workingCopyModel diffToReferenceCommit;
 		items: aCollection;
 		message: aString;
-		onSuccess: [ 
-			self verifyNeedsRefreshOrClose.
-			pushingBoolean ifTrue: [ 
-				(IceTipPushAction new repository: self repository) executeWithContext: self ].
-			savingBoolean ifTrue: [ 
-				saveAction execute ] ];
-		executeWithContext: self
+		onSuccess: [
+				self verifyNeedsRefreshOrClose.
+				pushingBoolean ifTrue: [ (IceTipPushAction new repository: self repository) executeWithContext: self ].
+				savingBoolean ifTrue: [ saveAction execute ] ];
+		executeWithContext: self.
+	commentPanel commitButton enabled: true
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
Fixes #1969
The user could missclikc and click again on the commit button while a commit is being executed before :)