### PR TITLE
Refresh Iceberg UI when switching tabs

### DIFF
--- a/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
+++ b/Iceberg-TipUI/IceTipEditProjectDialogPresenter.class.st
@@ -32,7 +32,7 @@ IceTipEditProjectDialogPresenter class >> defaultPreferredExtent [
 IceTipEditProjectDialogPresenter >> accept [
 
 	| newTagValue |
-	newTagValue := self tabList selectedItem group ifEmpty: [ 'projects' ] ifNotEmpty: [ :group | group ].
+	newTagValue := self tabList selectedItem group.
 	model repository project properties at: #tags put: { newTagValue asSymbol }.
 	IceTipStandardAction new
 		repository: model repository;
@@ -91,7 +91,9 @@ IceTipEditProjectDialogPresenter >> connectPresenters [
 				             text: '';
 				             acceptLabel: 'Confirm';
 				             cancelLabel: 'Cancel';
-				             onAccept: [ :dialog | model repository project properties at: #tags put: { dialog presenter text asSymbol } ];
+				             onAccept: [ :dialog |
+						             model repository project properties at: #tags put: { dialog presenter text asSymbol }.
+						             IceTipRepositoriesBrowser allInstancesDo: [ :instance | instance updatePresenter ] ];
 				             openDialog.
 			self closeWindow.
 			acceptCallback ifNotNil: [ acceptCallback value ] ].

--- a/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
@@ -279,17 +279,14 @@ IceTipRepositoriesBrowser >> subscribeToAnnouncements [
 { #category : 'initialization' }
 IceTipRepositoriesBrowser >> updatePresenter [
 
-	LGitLibrary uniqueInstance isAvailable 
-		ifFalse: [ self addLibGitNotAvailableWarning ].
-	
+	LGitLibrary uniqueInstance isAvailable ifFalse: [ self addLibGitNotAvailableWarning ].
 	self model repositoryGroups do: [ :group |
-		repositoryNotebook 
-			addPageTitle: group label 
-			provider: [ 
-				(self instantiate: IceTipRepositoryGroupPanel on: group)
-					transmitDo: [ "self refreshCommands" ];
-				yourself ] ].
-	
+			(repositoryNotebook pageNamed: group label) ifNil: [
+					repositoryNotebook addPageTitle: group label provider: [
+							(self instantiate: IceTipRepositoryGroupPanel on: group)
+								transmitDo: [ "self refreshCommands" ];
+								yourself ] ] ].
+
 	self refresh
 ]
 

--- a/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
@@ -281,7 +281,7 @@ IceTipRepositoriesBrowser >> updatePresenter [
 
 	LGitLibrary uniqueInstance isAvailable ifFalse: [ self addLibGitNotAvailableWarning ].
 	self model repositoryGroups do: [ :group |
-			(repositoryNotebook pageNamed: group label) ifNil: [
+			(repositoryNotebook hasPageNamed: group label) ifFalse: [
 					repositoryNotebook addPageTitle: group label provider: [
 							(self instantiate: IceTipRepositoryGroupPanel on: group)
 								transmitDo: [ "self refreshCommands" ];


### PR DESCRIPTION
- Firstly when selecting ```Projects``` as tab it was duplicating the tab, fixed now :) -Then when changing the tab of a repository, user needed to close and open the iceberg browser to refresh the tabs
- Fixes #1955.

