### PR TITLE
Pharo14: Do not add a default repository group if it is already present,

### DIFF
--- a/Iceberg-TipUI/IceTipRepositoriesModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesModel.class.st
@@ -62,7 +62,7 @@ IceTipRepositoriesModel >> repositoryGroups [
 		[ :each | each yourself ] ascending.
 
 	"add default group first if it is not there yet."
-	(groups isEmpty or: [ groups first = ''])
+	(groups isEmpty or: [ groups includes: ''])
 		ifFalse: [ groups := groups copyWithFirst: '' ].
 
 	^ groups collect: [ :each |


### PR DESCRIPTION
as opposed to the previous implementation: 'if it is the first group '. We just ordered the groups so the default group may be present even if not first.