### PR TITLE
Pressing enter when cloning a repository is bind to ok button now

### DIFF
--- a/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitProviderRepositoryPanel.class.st
@@ -33,6 +33,17 @@ IceTipGitProviderRepositoryPanel >> configureBuilder: aBuilder [
 	self subclassResponsibility
 ]
 
+{ #category : 'initialization' }
+IceTipGitProviderRepositoryPanel >> connectPresenters [
+
+	super connectPresenters.
+
+	projectNameInputText addShortcutWith: [ :action |
+			action
+				shortcutKey: Character cr asKeyCombination;
+				action: [ self owner accept ] ]
+]
+
 { #category : 'layout' }
 IceTipGitProviderRepositoryPanel >> defaultLayout [
 


### PR DESCRIPTION
- Previously the user always had to click the button to validate the clone action.
Also for me it is very intuitive to link the enter shortcut there( I always tried to do that :) )

- Only linked when we press enter in the ```projectNameInputText``` since the logical order is to enter your Git username and then the repository name. 
Maybe I can bind it to ```userNameInputText``` too, @jecisc what do you think ?

[Fixes #18381](https://github.com/pharo-project/pharo/issues/18381)