### PR TITLE
P14-fix-metacello-checkout-of-gitlab-subprojects

### DIFF
--- a/Iceberg-Metacello-Integration/IceProviderRepositoryType.class.st
+++ b/Iceberg-Metacello-Integration/IceProviderRepositoryType.class.st
@@ -75,11 +75,30 @@ IceProviderRepositoryType >> mcRepositoryClass [
 { #category : 'accessing' }
 IceProviderRepositoryType >> projectName [
 
-	^ (self location substrings: '/') third copyUpTo: $:
+	| parts mightBeProjectName |
+
+	"I need to handle the possibility that there are subprojects"
+	parts := self location substrings: '/'.
+	mightBeProjectName := parts allButFirst: 2.
+	
+	^ mightBeProjectName 
+		detect: [ :e | e includes: $: ]
+		ifFound: [ :e | e copyUpTo: $: ]
+		ifNone: [ parts third ]
 ]
 
 { #category : 'accessing' }
 IceProviderRepositoryType >> projectVersion [
 
-	^ (location substrings: '/') third copyAfter: $:
+	"I need to handle the possibility that there are subprojects"
+	| parts mightBeProjectName |
+	parts := self location substrings: '/'.
+	mightBeProjectName := parts allButFirst: 2.
+	
+	^ mightBeProjectName 
+		detect: [ :e | e includes: $: ]
+		ifFound: [ :e | e copyAfter: $: ]
+		ifNone: [ '' ]
+
+
 ]

--- a/Iceberg-Tests-MetacelloIntegration/IceMetacelloRepositoryTypeTest.class.st
+++ b/Iceberg-Tests-MetacelloIntegration/IceMetacelloRepositoryTypeTest.class.st
@@ -1,0 +1,123 @@
+Class {
+	#name : 'IceMetacelloRepositoryTypeTest',
+	#superclass : 'TestCase',
+	#category : 'Iceberg-Tests-MetacelloIntegration',
+	#package : 'Iceberg-Tests-MetacelloIntegration'
+}
+
+{ #category : 'tests' }
+IceMetacelloRepositoryTypeTest >> parse: url assertType: type projectName: projectName projectVersion: projectVersion [
+
+	| repo |
+	repo := IceMetacelloRepositoryType for: url.
+	self assert: repo class equals: type.
+	self assert: repo projectName equals: projectName.
+	self assert: repo projectVersion equals: projectVersion.
+]
+
+{ #category : 'tests' }
+IceMetacelloRepositoryTypeTest >> testParsingGithub [
+
+	self parse: 'github://pharo-project/pharo:master/src'
+		assertType: IceGithubRepositoryType 
+		projectName: 'pharo'
+		projectVersion: 'master'.
+
+	self parse: 'github://pharo-project/pharo:master'
+		assertType: IceGithubRepositoryType 
+		projectName: 'pharo'
+		projectVersion: 'master'.
+
+	self parse: 'github://pharo-project/pharo/src'
+		assertType: IceGithubRepositoryType 
+		projectName: 'pharo'
+		projectVersion: ''.
+
+	self parse: 'github://pharo-project/pharo/'
+		assertType: IceGithubRepositoryType 
+		projectName: 'pharo'
+		projectVersion: ''
+
+]
+
+{ #category : 'tests' }
+IceMetacelloRepositoryTypeTest >> testParsingGitlab [
+
+	self parse: 'gitlab://pharo-project/pharo:master/src'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+			
+	self parse: 'gitlab://pharo-project/pharo'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: ''.
+
+	self parse: 'gitlab://pharo-project/pharo/src'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: ''.
+
+	self parse: 'gitlab://pharo-project/subproject/pharo:master/src'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+
+]
+
+{ #category : 'tests' }
+IceMetacelloRepositoryTypeTest >> testParsingSelfHostedGitlab [
+
+	self parse: 'gitlab://git.pharo.org:pharo-project/pharo:master/src'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+	
+
+	self parse: 'gitlab://git.pharo.org:pharo-project/pharo:master'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+
+	self parse: 'gitlab://git.pharo.org:pharo-project/pharo'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: ''.
+
+	self parse: 'gitlab://git.pharo.org:pharo-project/pharo'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: ''.
+
+	self parse: 'gitlab://git.pharo.org:pharo-project/subproject/pharo:master/src'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+
+]
+
+{ #category : 'tests' }
+IceMetacelloRepositoryTypeTest >> testParsingSelfHostedGitlabWithNonLocalPort [
+
+	self parse: 'gitlab://git.pharo.org:1234:pharo-project/pharo:master/src'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+	
+
+	self parse: 'gitlab://git.pharo.org:1234:pharo-project/pharo:master'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+
+	self parse: 'gitlab://git.pharo.org:1234:pharo-project/pharo'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: ''.
+
+	self parse: 'gitlab://git.pharo.org:1234:pharo-project/subproject/pharo:master/src'
+		assertType: IceGitlabRepositoryType
+		projectName: 'pharo'
+		projectVersion: 'master'.
+
+]

--- a/Iceberg/IceMetacelloRepositoryAdapter.class.st
+++ b/Iceberg/IceMetacelloRepositoryAdapter.class.st
@@ -104,6 +104,10 @@ IceMetacelloRepositoryAdapter >> isValid [
 IceMetacelloRepositoryAdapter >> loadPackageNamed: aName intoLoader: aLoader [
 
 	| package found |
+
+	"We need to check if we have the correct version of the package"
+	self fetchPackageNamed: aName.
+
 	package := self repository workingCopy packageNamed: aName.
 	found := package latestVersion mcVersion.
 	aLoader addVersion: found.


### PR DESCRIPTION
- We need to support better URLs for the integration of Metacello request in private gitlabs with subprojects.
- Adding a test for the parsing
- Loading a package should first guarantee that the version is the correct one.