### PR TITLE
Miss select a folder to clone user input validation

### DIFF
--- a/Iceberg-TipUI/IceTipRepairLocateRepository.class.st
+++ b/Iceberg-TipUI/IceTipRepairLocateRepository.class.st
@@ -49,18 +49,23 @@ IceTipRepairLocateRepository class >> title [
 
 { #category : 'executing' }
 IceTipRepairLocateRepository >> basicExecute [
+
 	| dialog |
-	
 	dialog := (IceTipLocalRepositoryPanel newApplication: context application)
-		location: (self repository location ifNil: [ self defaultLocation ]);
-		yourself.
-	
-	dialog asDialogWindow 
-		okAction: [ 
-			dialog validate.
-			self repositoryModel updateLocation: dialog location.
-			true ];
+		          location: (self repository location ifNil: [ self defaultLocation ]);
+		          yourself.
+
+	dialog asDialogWindow
+		okAction: [
+				(IceRepositoryCreator isGitRoot: dialog location)
+					ifTrue: [
+							dialog validate.
+							self repositoryModel updateLocation: dialog location.
+							true ]
+					ifFalse: [ StPharoApplication current inform: dialog location , 'is not a git repository' ] ];
 		open.
+
+	
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
-By default when repairing a repository by using the `Locate repository in your file system`, there was no user input validation when clicking ok for a path, leading to a red square of death and breaking the image
- Fixes #1983
- Fixes https://github.com/pharo-project/pharo/issues/18661#issuecomment-3442035265
