### PR TITLE
MetacelloPharoPlatform>>#withMetacelloLoadSessionDo: is now in Pharo

### DIFF
--- a/Iceberg-Metacello-Integration/MetacelloPlatform.extension.st
+++ b/Iceberg-Metacello-Integration/MetacelloPlatform.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'MetacelloPlatform' }
-
-{ #category : '*Iceberg-Metacello-Integration' }
-MetacelloPlatform >> withMetacelloLoadSessionDo: aBlock [ 
-
-	aBlock value
-]


### PR DESCRIPTION
Remove this method from Iceberg since it is in Pharo directly.  This should fix some of the problems of Iceberg's CI