### PR TITLE
Remove a few unused methods and replace a deprecation warning

### DIFF
--- a/Iceberg-Libgit-Filetree/IceLibgitFiletreeReader.class.st
+++ b/Iceberg-Libgit-Filetree/IceLibgitFiletreeReader.class.st
@@ -85,12 +85,3 @@ IceLibgitFiletreeReader >> loadVersionInfo [
 IceLibgitFiletreeReader >> packageNameFromPackageDirectory [
 	^ iceVersion packageName
 ]
-
-{ #category : 'accessing' }
-IceLibgitFiletreeReader >> versionName [
-	^ ('{1}-{2}.{3}' format: {
-		self packageNameFromPackageDirectory. 
-		self commit compatibleUsername. 
-		self versionNumber
-	})
-]

--- a/Iceberg-Libgit-Filetree/IceLibgitFiletreeWriter.class.st
+++ b/Iceberg-Libgit-Filetree/IceLibgitFiletreeWriter.class.st
@@ -92,7 +92,6 @@ IceLibgitFiletreeWriter >> writeVersion: aVersion [
 	packageFileDirectory := stream / directory.
 
 	self packageFileDirectory ensureDeleteAll.
-	self writeFormat.
 	self writePackage: aVersion package.
 	self writeDefinitions: aVersion.
 	aVersion dependencies do: [ :ea | self writeVersionDependency: ea ]

--- a/Iceberg-Libgit-Filetree/IceMetadatalessFileTreeWriter.class.st
+++ b/Iceberg-Libgit-Filetree/IceMetadatalessFileTreeWriter.class.st
@@ -29,7 +29,6 @@ IceMetadatalessFileTreeWriter >> writeVersion: aVersion [
 	self deleteExistingPackageStructureFor: members.
 	self fileUtils ensureDirectoryExists: self packageFileDirectory.
 	self initializePackageFileDirectoryCache.
-	self writeFormat.
 	self writePackage: aVersion package.
 	self writeDefinitions: aVersion.
 	aVersion dependencies do: [ :ea | self writeVersionDependency: ea ]

--- a/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
+++ b/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
@@ -149,11 +149,11 @@ IceTipInteractiveErrorVisitor >> visitNoCommitMessage: aWarning [
 
 	| proceed |
 	proceed := context application newConfirm
-		           label: aWarning messageText;
+		           message: aWarning messageText;
 		           title: 'Warning!';
 		           acceptLabel: 'Commit';
 		           cancelLabel: 'Cancel';
-		         		openModal.
+		           openModal.
 
 	proceed ifFalse: [ ^ self ].
 	aWarning resume


### PR DESCRIPTION
This will allow to simplify a little more Monticello code afterward