### PR TITLE
Improve diff performance by caching writerClass

### DIFF
--- a/Iceberg-Libgit/IceGitCommit.class.st
+++ b/Iceberg-Libgit/IceGitCommit.class.st
@@ -7,7 +7,8 @@ Class {
 		'datetime',
 		'ancestorIds',
 		'comment',
-		'packageNamesCache'
+		'packageNamesCache',
+		'writerClass'
 	],
 	#category : 'Iceberg-Libgit-Core',
 	#package : 'Iceberg-Libgit',
@@ -220,5 +221,5 @@ IceGitCommit >> timeStamp [
 { #category : 'API - properties' }
 IceGitCommit >> writerClass [
 
-	^ self properties writerClass
+	^ writerClass ifNil: [ writerClass := self properties writerClass ]
 ]


### PR DESCRIPTION
The benefit of caching the writerClass is acknowledged in the comment of IceDiff>>#writerClass, but that implementation is not effective. The method #buildForChanges: will ultimately refer to the #writerClass of the source and target, and do so repeatedly, per changed file in the changes.

I made this change by profiling the following expression

```
myRepository branch diffTo: myRepository workingCopy
```

where the active branch of the repository is different from the reference commit of the working copy. There are roughly a thousand items in the collection passed to #buildForChanges:.

The duration drops from 9 to 6 seconds, more or less.