### PR TITLE
[Pharo 13 backport] Backport speed up of Iceberg diff computation

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        smalltalk: [ Pharo64-alpha ]
+        smalltalk: [ Pharo64-13 ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,14 @@ jobs:
       # Default value means that a failure in one OS cancels all 
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-alpha ]
+        smalltalk: [ Pharo64-13 ]
         os: [ ubuntu-latest, macos-latest ]
         ston: [ .smalltalk.ston ]
         # Test Windows with some exclusions. 
         # At least a part of the problem is reported here: 
         # https://github.com/pharo-vcs/iceberg/issues/1394
         include:
-          - smalltalk: Pharo64-alpha
+          - smalltalk: Pharo64-13
             os: windows-latest
             ston: .smalltalk.windows.ston
     runs-on: ${{ matrix.os }}

--- a/Iceberg-Libgit/IceGitCommit.class.st
+++ b/Iceberg-Libgit/IceGitCommit.class.st
@@ -7,7 +7,8 @@ Class {
 		'datetime',
 		'ancestorIds',
 		'comment',
-		'packageNamesCache'
+		'packageNamesCache',
+		'writerClass'
 	],
 	#category : 'Iceberg-Libgit-Core',
 	#package : 'Iceberg-Libgit',
@@ -220,5 +221,5 @@ IceGitCommit >> timeStamp [
 { #category : 'API - properties' }
 IceGitCommit >> writerClass [
 
-	^ self properties writerClass
+	^ writerClass ifNil: [ writerClass := self properties writerClass ]
 ]


### PR DESCRIPTION
I propose to backport the recent 2 PRs to speedup iceberg. We could merge it and release after a few days of testing the new Pharo14 image