### PR TITLE
Make diff for packages independent of file system

### DIFF
--- a/Iceberg-Libgit/IceGitChangeImporter.class.st
+++ b/Iceberg-Libgit/IceGitChangeImporter.class.st
@@ -56,14 +56,10 @@ IceGitChangeImporter >> importOn: aNode [
 	filePath := aNode path / currentSegment.
 	fileReference := version fileSystem resolve: filePath.
 		
-	"Do not import if the file does not exist in git"
-	fileReference exists
-		ifFalse: [ ^ self ].
-
 	"If I represent a package, let's do it and do nothing else.
 	This could be optimized to add the exact methods and avoid MC diff afterwards"
 	((diff isCodeSubdirectory: aNode)
-		and: [ version writerClass isValidPackage: fileReference ])
+		and: [ version includesPackageNamed: currentSegment ])
 			ifTrue: [ ^ self ensurePackageFromDirectory: fileReference inParentNode: aNode ].
 
 	"If I do not represent a package, I may be a file or a directory that may (recursively) contain a method or a package.


### PR DESCRIPTION
Removing packages from the file system can affect the outcome of a diff involving the working copy. This can come up during checkout or discard-and-load repair actions.

Consider the following scenario:
  - working copy is on branch A, with package P
  - there exists a branch B removing P
  - using git directly, checkout B
  - use discard-and-load to load B in the image

The expectation is that the preview shows the removal of P, but instead the diff is empty (or contains changes to other packages), and after proceeding with the checkout, package P is still present in the image.

This commit fixes that by
  - removing a general check on the existence of files. Both packages and files do their own existence checks.
  - switching the existince check for packages to looking at the reference commit and the image instead of the file system.