### PR TITLE
Redo of https://github.com/pharo-vcs/iceberg/pull/1918 (Introduce IceTipRepositoryStatusModel to avoid multiple commit lookups)

### DIFF
--- a/Iceberg-Libgit/IceGitCommit.class.st
+++ b/Iceberg-Libgit/IceGitCommit.class.st
@@ -8,6 +8,7 @@ Class {
 		'ancestorIds',
 		'comment',
 		'packageNamesCache',
+		'projectCache',
 		'writerClass'
 	],
 	#category : 'Iceberg-Libgit-Core',
@@ -182,7 +183,8 @@ IceGitCommit >> project [
 	
 	This is a quick fix of the issue for Pharo 7 release."
 
-	^ [ IceProjectReader readProjectFrom: self ] 
+	projectCache ifNotNil: [ ^ projectCache ].
+	^ [ projectCache := IceProjectReader readProjectFrom: self ] 
 		on: NotFound 
 		do: [ self repository fetch. IceProjectReader readProjectFrom: self ]
 ]

--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -729,10 +729,11 @@ IceLibgitRepository >> packageLocationFor: anIceSavedPackage [
 ]
 
 { #category : 'private - tags' }
-IceLibgitRepository >> peelTag: anIceTag [ 
-	self handleLibgitError: [ | lgitRef |
-		lgitRef := (self repositoryHandle lookup: 'refs/tags/', anIceTag name).
-		^ self lookupCommit: lgitRef targetId hexString ]
+IceLibgitRepository >> peelTag: anIceTag [
+
+	| id |
+	id := self tagTargetCommitId: anIceTag.
+	self handleLibgitError: [ ^ self lookupCommit: id ]
 ]
 
 { #category : 'API - project' }
@@ -885,6 +886,16 @@ IceLibgitRepository >> subdirectoryPath [
 IceLibgitRepository >> subdirectoryReference [
 	
 	^ self location resolve: self subdirectoryPath
+]
+
+{ #category : 'private - tags' }
+IceLibgitRepository >> tagTargetCommitId: anIceTag [
+
+	self handleLibgitError: [
+		| lgitRef |
+		lgitRef := self repositoryHandle lookup:
+			           'refs/tags/' , anIceTag name.
+		^ lgitRef targetId hexString ]
 ]
 
 { #category : 'API - tags' }

--- a/Iceberg-TipUI/IceTipRepositoryGroupPanel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryGroupPanel.class.st
@@ -147,7 +147,8 @@ IceTipRepositoryGroupPanel >> initializeRepositoryList [
 		beResizable;
 		addColumn: (SpStringTableColumn new
 			title: 'Repositories';
-			evaluated: #description;
+			evaluated: [ :x | x description ];
+			formatted: [ :each | each descriptionString ];
 			displayColor: [ :each | each descriptionDecorator color ];
 			displayBold: [ :each | each descriptionDecorator isBold ];
 			displayItalic: [ :each | each descriptionDecorator isItalic ];
@@ -156,7 +157,8 @@ IceTipRepositoryGroupPanel >> initializeRepositoryList [
 			yourself);
 		addColumn: (SpStringTableColumn new
 			title: 'Status';
-			evaluated: #status;
+			evaluated: [ :x | x status ];
+			formatted: [ :each | each statusString ];
 			displayColor: [ :each | each statusDecorator color ];
 			displayBold: [ :each | each statusDecorator isBold ];
 			displayItalic: [ :each | each statusDecorator isItalic ];
@@ -165,7 +167,8 @@ IceTipRepositoryGroupPanel >> initializeRepositoryList [
 			yourself);
 		addColumn: (SpStringTableColumn new
 			title: 'Branch';
-			evaluated: #branchName;
+			evaluated: [ :x | x status ];
+			formatted: [ :each | each branchName ];
 			yourself);
 		actions: self selectionCommandsGroup;
 		activateOnDoubleClick;

--- a/Iceberg-TipUI/IceTipRepositoryModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryModel.class.st
@@ -100,20 +100,8 @@ IceTipRepositoryModel >> createSourceDirectory [
 
 { #category : 'accessing' }
 IceTipRepositoryModel >> description [
-	| text |
-	
-	text := self displayString.
-	(self isLibGitAvailable and: [ self entity isModified ]) 
-		ifTrue: [ text := '*', text ].
-	^ text
-]
 
-{ #category : 'accessing' }
-IceTipRepositoryModel >> descriptionDecorator [
-
-	(self isLibGitAvailable and: [ self entity isModified ]) 
-		ifTrue: [ ^ IceTipDescriptionDecorator modified ].
-	^ super descriptionDecorator
+	^ IceTipRepositoryStatusModel on: self
 ]
 
 { #category : 'testing' }
@@ -431,100 +419,8 @@ IceTipRepositoryModel >> shortCommitId [
 
 { #category : 'accessing' }
 IceTipRepositoryModel >> status [
-	[
-		| status incoming outgoing | 
-
-		self verifyDirectoryStructureIfMissing: [ :message | ^ message asString ].
-		self isLibGitAvailable ifFalse: [ ^ 'Unknown (No libgit2)' ].
-		
-		entity workingCopy workingCopyState isUnknownCommitState 
-			ifTrue: [ ^ entity workingCopy workingCopyState description ].	
-		entity workingCopy isDetached 
-			ifTrue: [  ^ 'Detached Working Copy' ].
-		(entity head isDetached and: [ entity head tags isNotEmpty ])
-			ifTrue: [ ^ 'Detached HEAD' ].
-		entity head isDetached 
-			ifTrue: [ ^ 'Detached HEAD' ].
-
-		entity workingCopy project isUnborn
-			ifTrue: [ ^ 'No Project Found' ].
-
-		self isLoaded ifFalse: [ ^ 'Not loaded' ].
-
-		status := OrderedCollection new.
-		entity isModified ifTrue: [ status add: 'Uncommitted changes' ].
-		
-		incoming := self incomingCommits size.
-		incoming > 0 ifTrue: [ status add: ('{1} incoming' format: { incoming })].
-		
-		outgoing := self outgoingCommits size.
-		outgoing > 0 ifTrue: [ status add: ('{1} not published' format: { outgoing })].
-
-		status ifEmpty: [ status add: 'Up to date' ].
-		
-		^ ', ' join: status ] 
-	on: Error 
-	do: [ :e | ^ e description ]
-]
-
-{ #category : 'accessing' }
-IceTipRepositoryModel >> statusDecorator [
-
-	[
-		self entity isMissing 
-			ifTrue: [ ^ IceTipStatusDecorator error ].
-		entity workingCopy workingCopyState isUnknownCommitState 
-			ifTrue: [ ^ IceTipStatusDecorator error ].	
-		entity workingCopy isDetached 
-			ifTrue: [  ^ IceTipStatusDecorator error ].
-		(entity head isDetached and: [ entity head tags isNotEmpty ])
-			ifTrue: [ ^ IceTipStatusDecorator warning ].
-		entity head isDetached 
-			ifTrue: [ ^ IceTipStatusDecorator error ].
-		entity workingCopy project isUnborn
-			ifTrue: [ ^ IceTipStatusDecorator error ] 
-	] 
-	on: Error 
-	do: [ :e | ^ IceTipStatusDecorator error ].
 	
-	^ IceTipStatusDecorator none
-]
-
-{ #category : 'accessing' }
-IceTipRepositoryModel >> statusString [
-	[
-		| status incoming outgoing | 
-
-		self verifyDirectoryStructureIfMissing: [ :message | ^ message asString ].
-		
-		entity workingCopy workingCopyState isUnknownCommitState 
-			ifTrue: [ ^ entity workingCopy workingCopyState description ].	
-		entity workingCopy isDetached 
-			ifTrue: [  ^ 'Detached Working Copy' ].
-		(entity head isDetached and: [ entity head tags isNotEmpty ])
-			ifTrue: [ ^ 'Detached HEAD' ].
-		entity head isDetached 
-			ifTrue: [ ^ 'Detached HEAD' ].
-
-		entity workingCopy project isUnborn
-			ifTrue: [ ^ 'No Project Found' ].
-
-		self isLoaded ifFalse: [ ^ 'Not loaded' ].
-
-		status := OrderedCollection new.
-		entity isModified ifTrue: [ status add: 'Uncommitted changes' ].
-		
-		incoming := self incomingCommits size.
-		incoming > 0 ifTrue: [ status add: ('{1} incoming' format: { incoming })].
-		
-		outgoing := self outgoingCommits size.
-		outgoing > 0 ifTrue: [ status add: ('{1} not published' format: { outgoing })].
-
-		status ifEmpty: [ status add: 'Up to date' ].
-		
-		^ ', ' join: status ] 
-	on: Error 
-	do: [ :e | ^ e description ]
+	^ IceTipRepositoryStatusModel on: self
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipRepositoryModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryModel.class.st
@@ -104,6 +104,12 @@ IceTipRepositoryModel >> description [
 	^ IceTipRepositoryStatusModel on: self
 ]
 
+{ #category : 'accessing' }
+IceTipRepositoryModel >> descriptionDecorator [
+
+	^ self description descriptionDecorator
+]
+
 { #category : 'testing' }
 IceTipRepositoryModel >> hasRemotes [
 	^ self entity remotes isNotEmpty
@@ -421,6 +427,12 @@ IceTipRepositoryModel >> shortCommitId [
 IceTipRepositoryModel >> status [
 	
 	^ IceTipRepositoryStatusModel on: self
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryModel >> statusDecorator [
+	
+	^ self status statusDecorator
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipRepositoryStatusModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryStatusModel.class.st
@@ -1,0 +1,171 @@
+"
+I represent the status of a repository at a given time to be shown. I cache all results to avoid multiple lookups.
+"
+Class {
+	#name : 'IceTipRepositoryStatusModel',
+	#superclass : 'IceTipModel',
+	#instVars : [
+		'repositoryModel',
+		'head',
+		'isMissing',
+		'workingCopy',
+		'isDetached',
+		'isModified',
+		'project',
+		'workingCopyState'
+	],
+	#category : 'Iceberg-TipUI-Model',
+	#package : 'Iceberg-TipUI',
+	#tag : 'Model'
+}
+
+{ #category : 'instance creation' }
+IceTipRepositoryStatusModel class >> on: aRepositoryModel [
+
+	^ self new
+		  repositoryModel: aRepositoryModel;
+		  yourself
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> branchName [
+
+	(repositoryModel isLibGitAvailable not or: [ self isMissing ]) 
+		ifTrue: [ ^ repositoryModel class unknownBranchLabel ].
+	
+	^ self head description
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> descriptionDecorator [
+
+	(repositoryModel isLibGitAvailable and: [ self isRepositoryModified ]) 
+		ifTrue: [ ^ IceTipDescriptionDecorator modified ].
+	^ IceTipTextDecorator none
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> descriptionString [
+	| text |
+	
+	text := repositoryModel displayString.
+	(repositoryModel isLibGitAvailable and: [ self isRepositoryModified ]) 
+		ifTrue: [ text := '*', text ].
+	^ text
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> entity [
+
+	^ repositoryModel entity
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> head [
+
+	^ head ifNil: [ head := self entity head ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> isDetached [
+	
+	^ isDetached ifNil: [ isDetached := self workingCopy isDetached ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> isMissing [
+
+	^ isMissing ifNil: [ isMissing := self entity isMissing ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> isModified [
+
+	^ isModified ifNil: [ isModified := self workingCopy isModified ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> isRepositoryModified [
+
+	^ isModified ifNil: [ isModified := self entity isModified ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> project [
+
+	^ project ifNil: [ project := self workingCopy project ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> repositoryModel: anIceTipRepositoryModel [ 
+	repositoryModel := anIceTipRepositoryModel
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> statusDecorator [
+
+	[
+	self isMissing ifTrue: [ ^ IceTipStatusDecorator error ].
+	self workingCopyState isUnknownCommitState ifTrue: [
+		^ IceTipStatusDecorator error ].
+	self isDetached ifTrue: [
+		^ IceTipStatusDecorator error ].
+	self head isDetached ifTrue: [ ^ IceTipStatusDecorator warning ].
+	self project isUnborn ifTrue: [
+		^ IceTipStatusDecorator error ] ]
+		on: Error
+		do: [ :e | ^ IceTipStatusDecorator error ].
+
+	^ IceTipStatusDecorator none
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> statusString [
+
+	| state |
+	[
+	| status incoming outgoing |
+	repositoryModel verifyDirectoryStructureIfMissing: [ :message |
+		^ message asString ].
+	repositoryModel isLibGitAvailable ifFalse: [ ^ 'Unknown (No libgit2)' ].
+
+	state := self workingCopy workingCopyState.
+	state isUnknownCommitState ifTrue: [
+		^ state description ].
+	self isDetached ifTrue: [ ^ 'Detached Working Copy' ].
+
+	self head isDetached ifTrue: [ ^ 'Detached HEAD' ].
+
+	self project isUnborn ifTrue: [ ^ 'No Project Found' ].
+
+	repositoryModel isLoaded ifFalse: [ ^ 'Not loaded' ].
+
+	status := OrderedCollection new.
+	self entity isModified ifTrue: [ status add: 'Uncommitted changes' ].
+
+	incoming := repositoryModel incomingCommits size.
+	incoming > 0 ifTrue: [
+		status add: ('{1} incoming' format: { incoming }) ].
+
+	outgoing := repositoryModel outgoingCommits size.
+	outgoing > 0 ifTrue: [
+		status add: ('{1} not published' format: { outgoing }) ].
+
+	status ifEmpty: [ status add: 'Up to date' ].
+
+	^ ', ' join: status ]
+		on: Error
+		do: [ :e | ^ e description ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> workingCopy [
+	
+	^ workingCopy ifNil: [ workingCopy := self entity workingCopy ]
+]
+
+{ #category : 'accessing' }
+IceTipRepositoryStatusModel >> workingCopyState [
+	
+	^ workingCopyState ifNil: [ workingCopyState := self workingCopy workingCopyState ]
+]

--- a/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
+++ b/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
@@ -145,20 +145,20 @@ IceTipWorkingCopyBrowser >> initializePackagesTable [
 
 	packagesTable
 		beResizable;
-		addColumn: (SpImageTableColumn new 
+		addColumn: (SpImageTableColumn new
 			beNotExpandable;
 			evaluated: [ :aPackage | self iconFor: aPackage ];
 			yourself);
 		addColumn: (SpStringTableColumn new
 			title: 'Name';
-			evaluated: #description;
+			formatted: #description;
 			displayColor: [ :each | each descriptionDecorator color ];
 			displayBold: [ :each | each descriptionDecorator isBold ];
 			displayItalic: [ :each | each descriptionDecorator isItalic ];			
 			yourself);
 		addColumn: (SpStringTableColumn new
 			title: 'Status';
-			evaluated: #status;
+			formatted: #status;
 			displayColor: [ :each | each descriptionDecorator color ];
 			displayBold: [ :each | each descriptionDecorator isBold ];
 			displayItalic: [ :each | each descriptionDecorator isItalic ];			

--- a/Iceberg-TipUI/IceTipWorkingCopyStatusBarPresenter.class.st
+++ b/Iceberg-TipUI/IceTipWorkingCopyStatusBarPresenter.class.st
@@ -44,14 +44,16 @@ IceTipWorkingCopyStatusBarPresenter >> initializePresenters [
 IceTipWorkingCopyStatusBarPresenter >> model: aModel [
 	"Fill labels from a IceTipWorkingCopyModel."
 
+	| status |
 	aModel shortCommitId
 		ifNil: [ self refreshWithoutCommitId: aModel ]
 		ifNotNil: [ self refreshWithCommitId: aModel ].
-	statusLabel 
-		label: aModel status;
-		displayColor: [ :aString | aModel statusDecorator color ];
-		displayBold: [ :aString | aModel statusDecorator isBold ].
 
+	status := aModel status.
+	statusLabel
+		label: status statusString;
+		displayColor: [ :aString | status statusDecorator color ];
+		displayBold: [ :aString | status statusDecorator isBold ]
 ]
 
 { #category : 'accessing' }

--- a/Iceberg/IceCommit.class.st
+++ b/Iceberg/IceCommit.class.st
@@ -307,7 +307,7 @@ IceCommit >> status [
 { #category : 'API - tags' }
 IceCommit >> tags [
 	
-	^ self repository tags select: [ :each | each commit = self ]
+	^ self repository tags select: [ :each | each commitId = self id ]
 ]
 
 { #category : 'accessing' }

--- a/Iceberg/IceTag.class.st
+++ b/Iceberg/IceTag.class.st
@@ -23,6 +23,12 @@ IceTag >> commit [
 	^ commit ifNil: [ commit := self repository peelTag: self ]
 ]
 
+{ #category : 'querying' }
+IceTag >> commitId [
+
+	^ self repository tagTargetCommitId: self
+]
+
 { #category : 'API - tags' }
 IceTag >> delete [
 


### PR DESCRIPTION
This is a redo of the PR I reverted with a fix so that Iceberg's UI work again. 

But this still has a problem. @guillep introduced the IceTipRepositoryStatusModel so that we access less the commit info through FFI. This was based on the idea that #displayColor:, #displayBold: and #displayItalic: are based on the result of #evaluated:. Like this, we could compute the status and descriptions only once and reuse them. 

But this does not work like this. Those methods are called directly on the object of the line making the optimization useless because it will still recompute the status and description for each column all the time. 

For more info see discussion there: https://github.com/pharo-spec/Spec/issues/1861

So this still needs more work. We need to find a way to cache those info and to know when to invalidate them because the current PR will not bring much improvements