### PR TITLE
Improve the iceberg world menu

### DIFF
--- a/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
+++ b/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
@@ -100,11 +100,11 @@ IceTipInteractiveErrorVisitor >> visitExperimentalFeature: aWarning [
 
 	| proceed |
 	proceed := context application newConfirm
-		           label: aWarning messageText;
+		           message: aWarning messageText;
 		           title: 'Warning!';
 		           acceptLabel: 'Continue';
 		           cancelLabel: 'Cancel';
-					openModal.
+		           openModal.
 	proceed ifFalse: [ ^ self ].
 	aWarning resume
 ]

--- a/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
@@ -89,17 +89,18 @@ IceTipRepositoriesBrowser class >> iconForWorldMenu [
 ]
 
 { #category : 'world menu' }
-IceTipRepositoriesBrowser class >> menuCommandOn: aBuilder [ 
-	"Add a custom menu item to the world menu"	
-	<worldMenu> 
-	
-	(aBuilder item: #'Git Repositories Browser')
-		order: 1;
-		icon: self iconForWorldMenu;
-		parent: #'Versioning';
-		keyText: 'o, i';
-		help: 'Iceberg is a set of tools that allow one to handle git repositories directly from a Pharo image.';
-		action: [ self new open ]
+IceTipRepositoriesBrowser class >> menuCommandOn: aBuilder [
+	"Add a custom menu item to the world menu. We add Iceberg to two menus"
+
+	<worldMenu>
+	{ #Browsing. #Versioning } do: [ :parent |
+			(aBuilder item: #'Git Repositories Browser')
+				order: 1;
+				icon: self iconForWorldMenu;
+				parent: parent;
+				keyText: 'o, i';
+				help: 'Iceberg is a set of tools that allow one to handle git repositories directly from a Pharo image.';
+				action: [ self ensureIsOpen ] ]
 ]
 
 { #category : 'instance creation' }


### PR DESCRIPTION
- Use #ensureIsOpen instead of #open
- Merge IceTipRepositoriesBrowser class>>#menuCommandOn: and part of PharoCommonTools class>>#worldMenuOn:. This allow to cut a dependency from the core of Pharo to Iceberg. It's Iceberg that should declare its dependencies 
- Fix a deprecation