### PR TITLE
Add progress bars

### DIFF
--- a/Iceberg-Libgit/IceGitCommit.class.st
+++ b/Iceberg-Libgit/IceGitCommit.class.st
@@ -7,8 +7,7 @@ Class {
 		'datetime',
 		'ancestorIds',
 		'comment',
-		'packageNamesCache',
-		'writerClass'
+		'packageNamesCache'
 	],
 	#category : 'Iceberg-Libgit-Core',
 	#package : 'Iceberg-Libgit',
@@ -220,5 +219,5 @@ IceGitCommit >> timeStamp [
 { #category : 'API - properties' }
 IceGitCommit >> writerClass [
 
-	^ writerClass ifNil: [ writerClass := self properties writerClass ]
+	^ self properties writerClass
 ]

--- a/Iceberg/IceCommitish.class.st
+++ b/Iceberg/IceCommitish.class.st
@@ -28,6 +28,7 @@ Class {
 	#name : 'IceCommitish',
 	#superclass : 'Object',
 	#instVars : [
+		'properties',
 		'repository'
 	],
 	#category : 'Iceberg-Core',
@@ -231,9 +232,9 @@ IceCommitish >> project [
 
 { #category : 'API - properties' }
 IceCommitish >> properties [
-	^ IceRepositoryProperties
-		fromFileReferenceDirectory: self project sourceDirectoryReference
-		commitish: self
+	"Caching for performance reasons. We might ask them multiple times by operation and it takes time to compute."
+
+	^ properties ifNil: [ properties := IceRepositoryProperties fromFileReferenceDirectory: self project sourceDirectoryReference commitish: self ]
 ]
 
 { #category : 'API - properties' }

--- a/Iceberg/IceDiff.class.st
+++ b/Iceberg/IceDiff.class.st
@@ -84,7 +84,8 @@ IceDiff >> buildForChanges: aCollection [
 						 diff: self;
 						 parentNode: rightTree;
 						 yourself) ]
-		displayingProgress: [ :change | change displayingProgressString ].
+		displayingProgress: [ :change | change displayingProgressString ]
+		every: 200.
 
 	mergedTree := self mergedTreeOf: leftTree with: rightTree.
 	tree := mergedTree select: [ :operation | operation hasChanges ]

--- a/Iceberg/IceDiff.class.st
+++ b/Iceberg/IceDiff.class.st
@@ -71,21 +71,23 @@ IceDiff >> buildForChanges: aCollection [
 	leftTree := IceNode value: IceRootDefinition new.
 	rightTree := IceNode value: IceRootDefinition new.
 
-	aCollection do: [ :change | 
-		change accept: (IceChangeImporter new
-			version: source;
-			diff: self;
-			parentNode: leftTree;
-			yourself).
-			
-		change accept: (IceChangeImporter new
-			version: target;
-			diff: self;
-			parentNode: rightTree;
-			yourself) ] "displayingProgress: [ :change | change displayingProgressString ]".
+	aCollection
+		do: [ :change |
+				change accept: (IceChangeImporter new
+						 version: source;
+						 diff: self;
+						 parentNode: leftTree;
+						 yourself).
+
+				change accept: (IceChangeImporter new
+						 version: target;
+						 diff: self;
+						 parentNode: rightTree;
+						 yourself) ]
+		displayingProgress: [ :change | change displayingProgressString ].
 
 	mergedTree := self mergedTreeOf: leftTree with: rightTree.
-	tree := mergedTree select: [ :operation | operation hasChanges ].
+	tree := mergedTree select: [ :operation | operation hasChanges ]
 ]
 
 { #category : 'building' }


### PR DESCRIPTION
Since recent speed up made some progress bars so fast to display, we should enable back some old progress bars.

I also added a speedup of the snapshot computation by caching the properties of a commit that are asked a lot during the diff of Iceberg