### PR TITLE
Cleanup extensions

### DIFF
--- a/Iceberg-Libgit-Filetree/IceLibgitFiletreeReader.class.st
+++ b/Iceberg-Libgit-Filetree/IceLibgitFiletreeReader.class.st
@@ -5,7 +5,7 @@ Currently we only support metadata-less repositories.
 "
 Class {
 	#name : 'IceLibgitFiletreeReader',
-	#superclass : 'MCFileTreeStCypressReader',
+	#superclass : 'MCFileTreeReader',
 	#traits : 'TIceRepositoryReader',
 	#classTraits : 'TIceRepositoryReader classTrait',
 	#instVars : [

--- a/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
+++ b/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
@@ -89,8 +89,7 @@ IceTipInteractiveErrorVisitor >> visitCloneLocationAlreadyExists: anError [
 IceTipInteractiveErrorVisitor >> visitCloneRemoteNotFound: anError [
 
 	context application newInform
-		label: ('The clone remote {1} could not been found' format:
-				 { anError remoteUrl });
+		message: ('The clone remote {1} could not been found' format: { anError remoteUrl });
 		title: 'Clone action failed';
 		openModal
 ]

--- a/Iceberg/MCPatcher.extension.st
+++ b/Iceberg/MCPatcher.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'MCPatcher' }
-
-{ #category : '*Iceberg' }
-MCPatcher >> definitions [
-	^ definitions
-]

--- a/Iceberg/MCWorkingCopy.extension.st
+++ b/Iceberg/MCWorkingCopy.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'MCWorkingCopy' }
-
-{ #category : '*Iceberg' }
-MCWorkingCopy >> info [
-	^ self versionInfo
-]


### PR DESCRIPTION
Move extensions to proper places:
 - to the defining classes if possible
 - to the user if (and very clear) there is only one
 - close to other similar extensions if possible

Related to https://github.com/pharo-project/pharo/pull/19150