### PR TITLE
[New Feature] Propose repair actions when checkout existing local branch

### DIFF
--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -377,7 +377,7 @@ IceLibgitRepository >> createBranch: branchName [
 					self repositoryHandle setHead: newBranch ] ]
 				on: LGit_GIT_EEXISTS
 				do: [ :error | 
-					IceBranchAlreadyExists new
+					IceBranchAlreadyExistsError new
 						branchName: branchName;
 						signal ].
 			^ self head ]

--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -377,7 +377,7 @@ IceLibgitRepository >> createBranch: branchName [
 					self repositoryHandle setHead: newBranch ] ]
 				on: LGit_GIT_EEXISTS
 				do: [ :error | 
-					IceBranchAlreadyExistsError new
+					IceBranchAlreadyExistsError new 
 						branchName: branchName;
 						signal ].
 			^ self head ]

--- a/Iceberg-Memory/IceMemoryRepository.class.st
+++ b/Iceberg-Memory/IceMemoryRepository.class.st
@@ -192,7 +192,7 @@ IceMemoryRepository >> createBranch: branchName inCommit: aCommit [
 		ifTrue: [ ^ head := IceMemoryUnbornBranch inRepository: self named: branchName ].
 
 	(self hasBranchNamed: branchName)
-		ifTrue: [ IceBranchAlreadyExists new
+		ifTrue: [ IceBranchAlreadyExistsError new
 			branchName: branchName;
 			signal ].
 	

--- a/Iceberg-Tests/IceBornRepositoryTest.class.st
+++ b/Iceberg-Tests/IceBornRepositoryTest.class.st
@@ -57,7 +57,7 @@ IceBornRepositoryTest >> testBranchAlreadyExistsErrorInformsExistingBranchName [
 	branchName := 'master'.
 	[ self repository createBranch: branchName.
 	  self fail ]
-		on: IceBranchAlreadyExists
+		on: IceBranchAlreadyExistsError
 	 	do: [ :error | self assert: error branchName equals: branchName ]
 ]
 

--- a/Iceberg-Tests/IceBornRepositoryTest.class.st
+++ b/Iceberg-Tests/IceBornRepositoryTest.class.st
@@ -88,7 +88,7 @@ IceBornRepositoryTest >> testCreateExistingBranchRaisesError [
 
 	self repository head isUnbornBranch ifTrue: [ ^ self skip ].
 	
-	self should: [self repository createBranch: 'master'] raise: IceBranchAlreadyExists
+	self should: [self repository createBranch: 'master'] raise: IceBranchAlreadyExistsError 
 ]
 
 { #category : 'tests-tags' }

--- a/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
+++ b/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : 'IceTipBranchConflictResolutionDialog',
+	#superclass : 'IceTipOptionDialogPresenter',
+	#instVars : [
+		'model',
+		'types'
+	],
+	#category : 'Iceberg-TipUI-View-Branch',
+	#package : 'Iceberg-TipUI',
+	#tag : 'View-Branch'
+}
+
+{ #category : 'instance creation' }
+IceTipBranchConflictResolutionDialog class >> onRepository: aRepository [
+
+	^ self on: (IceTipRepositoryModel on: aRepository)
+]
+
+{ #category : 'accessing' }
+IceTipBranchConflictResolutionDialog >> allTypes [
+
+	^ types ifNil: [ types := self createConflictBranchTypes ]
+]
+
+{ #category : 'as yet unclassified' }
+IceTipBranchConflictResolutionDialog >> createConflictBranchTypes [
+
+^nil
+]
+
+{ #category : 'actions' }
+IceTipBranchConflictResolutionDialog >> doAccept [
+
+	self selectedType doAccept
+]
+
+{ #category : 'accessing' }
+IceTipBranchConflictResolutionDialog >> windowTitle [
+
+	^ 'Resolve branch conflict'
+]

--- a/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
+++ b/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
@@ -53,12 +53,7 @@ IceTipBranchConflictResolutionDialog >> createConflictBranchTypes [
 IceTipBranchConflictResolutionDialog >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		  add: reasonPanel withConstraints: [ :constraints |
-				  constraints
-					  expand: false;
-					  fill: false;
-					  height: 20 ];
-		  spacing: 10;
+		  add: reasonPanel expand: false;
 		  add: super defaultLayout;
 		  yourself
 ]

--- a/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
+++ b/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
@@ -2,8 +2,9 @@ Class {
 	#name : 'IceTipBranchConflictResolutionDialog',
 	#superclass : 'IceTipOptionDialogPresenter',
 	#instVars : [
-		'model',
-		'types'
+		'existingBranch',
+		'types',
+		'model'
 	],
 	#category : 'Iceberg-TipUI-View-Branch',
 	#package : 'Iceberg-TipUI',
@@ -16,6 +17,14 @@ IceTipBranchConflictResolutionDialog class >> onRepository: aRepository [
 	^ self on: (IceTipRepositoryModel on: aRepository)
 ]
 
+{ #category : 'instance creation' }
+IceTipBranchConflictResolutionDialog class >> onRepository: aRepository existingBranch: aBranch [
+
+	^ (self on: (IceTipRepositoryModel on: aRepository))
+		  existingBranch: aBranch;
+		  yourself
+]
+
 { #category : 'accessing' }
 IceTipBranchConflictResolutionDialog >> allTypes [
 
@@ -25,13 +34,45 @@ IceTipBranchConflictResolutionDialog >> allTypes [
 { #category : 'as yet unclassified' }
 IceTipBranchConflictResolutionDialog >> createConflictBranchTypes [
 
-^nil
+	| allTypes |
+	"Collect types new+local+remotes"
+	allTypes := {
+		            (IceTipCheckoutNewBranchPanel on: self model). "New branch"
+		            ((IceTipCheckoutBranchPanel on: self model)
+			             titleForWindow: 'Local';
+			             icon: (self iconNamed: #branch);
+			             yourself) } , (self model remoteModels collect: [ :each |
+			             (IceTipCheckoutBranchPanel on: each)
+				             titleForWindow: each name;
+				             icon: (self iconNamed: #remote);
+				             yourself ]) , (self model entity pluginManager checkoutBranchPanelsOnModel: self model). "Doing this because I can trigger the accept inside the panels."
+	allTypes do: [ :each | each onAccept: [ self closeWindow ] ].
+
+	^ allTypes
 ]
 
 { #category : 'actions' }
 IceTipBranchConflictResolutionDialog >> doAccept [
 
 	self selectedType doAccept
+]
+
+{ #category : 'accessing' }
+IceTipBranchConflictResolutionDialog >> existingBranch: aBranch [
+
+	existingBranch := aBranch
+]
+
+{ #category : 'accessing' }
+IceTipBranchConflictResolutionDialog >> model [
+
+	^ model
+]
+
+{ #category : 'accessing - model' }
+IceTipBranchConflictResolutionDialog >> setModelBeforeInitialization: anObject [
+
+	model := anObject
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
+++ b/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
@@ -5,7 +5,9 @@ Class {
 		'existingBranch',
 		'types',
 		'model',
-		'reasonPanel'
+		'reasonPanel',
+		'resultBranch',
+		'remoteBranch'
 	],
 	#category : 'Iceberg-TipUI-View-Branch',
 	#package : 'Iceberg-TipUI',
@@ -19,7 +21,7 @@ IceTipBranchConflictResolutionDialog class >> onRepository: aRepository [
 ]
 
 { #category : 'instance creation' }
-IceTipBranchConflictResolutionDialog class >> onRepository: aRepository existingBranch: aBranch [
+IceTipBranchConflictResolutionDialog class >> onRepository: aRepository remoteBranch: aRemote existingBranch: aBranch [
 
 	^ (self on: (IceTipRepositoryModel on: aRepository))
 		  existingBranch: aBranch;
@@ -32,7 +34,7 @@ IceTipBranchConflictResolutionDialog >> allTypes [
 	^ types ifNil: [ types := self createConflictBranchTypes ]
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'private - factory' }
 IceTipBranchConflictResolutionDialog >> createConflictBranchTypes [
 
 	| allTypes |
@@ -47,8 +49,12 @@ IceTipBranchConflictResolutionDialog >> createConflictBranchTypes [
 IceTipBranchConflictResolutionDialog >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		  add: reasonPanel;
-		  spacing: 40;
+		  add: reasonPanel withConstraints: [ :constraints |
+				  constraints
+					  expand: false;
+					  fill: false;
+					  height: 20 ];
+		  spacing: 10;
 		  add: super defaultLayout;
 		  yourself
 ]
@@ -56,40 +62,51 @@ IceTipBranchConflictResolutionDialog >> defaultLayout [
 { #category : 'actions' }
 IceTipBranchConflictResolutionDialog >> doAccept [
 
-	self selectedType doAccept
+	resultBranch := type executeFor: remoteBranch localBranch: existingBranch inRepository: self model repository
 ]
 
 { #category : 'accessing' }
 IceTipBranchConflictResolutionDialog >> existingBranch: aBranch [
 
-	existingBranch := aBranch
+	existingBranch := aBranch.
+	self initializeReasonPanel
 ]
 
 { #category : 'initialization' }
 IceTipBranchConflictResolutionDialog >> initializePresenters [
 
 	super initializePresenters.
-	reasonPanel := self newText
-		               beNotEditable;
+	reasonPanel := self newLabel
 		               addStyle: 'iceTipReadonly';
-		               beWrapWord;
 		               yourself.
-	self initializeReasonPanel.
+	
 	self allTypes
 ]
 
 { #category : 'initialization' }
 IceTipBranchConflictResolutionDialog >> initializeReasonPanel [
 
-	reasonPanel text: 'The branch already exists in your local repository. 
-Iceberg cannot check out the remote branch because doing so would overwrite the existing local branch. 
-What would you like to do?'
+	reasonPanel label: 'The branch ' , existingBranch name , ' already exists in your local repository.' , String cr
+		, 'Iceberg cannot check out the remote branch because doing so would overwrite the existing local branch.' , String cr
+		, 'What would you like to do?'
 ]
 
 { #category : 'accessing' }
 IceTipBranchConflictResolutionDialog >> model [
 
 	^ model
+]
+
+{ #category : 'accessing' }
+IceTipBranchConflictResolutionDialog >> remoteBranch: aRemoteBranch [
+
+	remoteBranch := aRemoteBranch
+]
+
+{ #category : 'accessing' }
+IceTipBranchConflictResolutionDialog >> resultBranch [
+
+	^ resultBranch
 ]
 
 { #category : 'accessing - model' }

--- a/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
+++ b/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'existingBranch',
 		'types',
-		'model'
+		'model',
+		'reasonPanel'
 	],
 	#category : 'Iceberg-TipUI-View-Branch',
 	#package : 'Iceberg-TipUI',
@@ -36,19 +37,20 @@ IceTipBranchConflictResolutionDialog >> createConflictBranchTypes [
 
 	| allTypes |
 	"Collect types new+local+remotes"
-	allTypes := {
-		            (IceTipCheckoutNewBranchPanel on: self model). "New branch"
-		            ((IceTipCheckoutBranchPanel on: self model)
-			             titleForWindow: 'Local';
-			             icon: (self iconNamed: #branch);
-			             yourself) } , (self model remoteModels collect: [ :each |
-			             (IceTipCheckoutBranchPanel on: each)
-				             titleForWindow: each name;
-				             icon: (self iconNamed: #remote);
-				             yourself ]) , (self model entity pluginManager checkoutBranchPanelsOnModel: self model). "Doing this because I can trigger the accept inside the panels."
+	allTypes := { (IceTipCancelBranchPanel on: self model) }.
 	allTypes do: [ :each | each onAccept: [ self closeWindow ] ].
 
 	^ allTypes
+]
+
+{ #category : 'layout' }
+IceTipBranchConflictResolutionDialog >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: reasonPanel;
+		  spacing: 40;
+		  add: super defaultLayout;
+		  yourself
 ]
 
 { #category : 'actions' }
@@ -61,6 +63,27 @@ IceTipBranchConflictResolutionDialog >> doAccept [
 IceTipBranchConflictResolutionDialog >> existingBranch: aBranch [
 
 	existingBranch := aBranch
+]
+
+{ #category : 'initialization' }
+IceTipBranchConflictResolutionDialog >> initializePresenters [
+
+	super initializePresenters.
+	reasonPanel := self newText
+		               beNotEditable;
+		               addStyle: 'iceTipReadonly';
+		               beWrapWord;
+		               yourself.
+	self initializeReasonPanel.
+	self allTypes
+]
+
+{ #category : 'initialization' }
+IceTipBranchConflictResolutionDialog >> initializeReasonPanel [
+
+	reasonPanel text: 'The branch already exists in your local repository. 
+Iceberg cannot check out the remote branch because doing so would overwrite the existing local branch. 
+What would you like to do?'
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
+++ b/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
@@ -86,9 +86,16 @@ IceTipBranchConflictResolutionDialog >> initializePresenters [
 { #category : 'initialization' }
 IceTipBranchConflictResolutionDialog >> initializeReasonPanel [
 
-	reasonPanel label: 'The branch ' , existingBranch name , ' already exists in your local repository.' , String cr
-		, 'Iceberg cannot check out the remote branch because doing so would overwrite the existing local branch.' , String cr
-		, 'What would you like to do?'
+	| line1 line2 line3 |
+	line1 := 'The branch ' , existingBranch name , ' already exists in your local repository.'.
+	line2 := 'Iceberg cannot check out the remote branch because doing so would overwrite the existing local branch.'.
+	line3 := 'What would you like to do?'.
+
+	reasonPanel := SpBoxLayout newTopToBottom
+		               add: (self newLabel label: line1) expand: false;
+		               add: (self newLabel label: line2) expand: false;
+		               add: (self newLabel label: line3) expand: false;
+		               yourself
 ]
 
 { #category : 'initialization' }

--- a/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
+++ b/Iceberg-TipUI/IceTipBranchConflictResolutionDialog.class.st
@@ -21,9 +21,10 @@ IceTipBranchConflictResolutionDialog class >> onRepository: aRepository [
 ]
 
 { #category : 'instance creation' }
-IceTipBranchConflictResolutionDialog class >> onRepository: aRepository remoteBranch: aRemote existingBranch: aBranch [
+IceTipBranchConflictResolutionDialog class >> onRepository: aRepository remoteBranch: aRemoteBranch existingBranch: aBranch [
 
 	^ (self on: (IceTipRepositoryModel on: aRepository))
+		  remoteBranch: aRemoteBranch;
 		  existingBranch: aBranch;
 		  yourself
 ]
@@ -39,7 +40,10 @@ IceTipBranchConflictResolutionDialog >> createConflictBranchTypes [
 
 	| allTypes |
 	"Collect types new+local+remotes"
-	allTypes := { (IceTipCancelBranchPanel on: self model) }.
+	allTypes := {
+		            (IceTipConflictCheckoutAsNewPanel on: self model).
+		            (IceTipConflictCheckoutReplaceLocalPanel on: self model).
+		            (IceTipCancelBranchPanel on: self model) }.
 	allTypes do: [ :each | each onAccept: [ self closeWindow ] ].
 
 	^ allTypes
@@ -69,6 +73,7 @@ IceTipBranchConflictResolutionDialog >> doAccept [
 IceTipBranchConflictResolutionDialog >> existingBranch: aBranch [
 
 	existingBranch := aBranch.
+	self initializeTypeVariables.
 	self initializeReasonPanel
 ]
 
@@ -80,7 +85,7 @@ IceTipBranchConflictResolutionDialog >> initializePresenters [
 		               addStyle: 'iceTipReadonly';
 		               yourself.
 	
-	self allTypes
+
 ]
 
 { #category : 'initialization' }
@@ -89,6 +94,15 @@ IceTipBranchConflictResolutionDialog >> initializeReasonPanel [
 	reasonPanel label: 'The branch ' , existingBranch name , ' already exists in your local repository.' , String cr
 		, 'Iceberg cannot check out the remote branch because doing so would overwrite the existing local branch.' , String cr
 		, 'What would you like to do?'
+]
+
+{ #category : 'initialization' }
+IceTipBranchConflictResolutionDialog >> initializeTypeVariables [
+
+	types do: [ :panel |
+			panel
+				remoteBranch: remoteBranch;
+				existingBranch: existingBranch ]
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipCancelBranchPanel.class.st
+++ b/Iceberg-TipUI/IceTipCancelBranchPanel.class.st
@@ -1,14 +1,25 @@
+"
+I'm a panel to cancel a checkout branch action.
+"
 Class {
 	#name : 'IceTipCancelBranchPanel',
 	#superclass : 'IceTipBranchPanel',
 	#instVars : [
 		'title',
-		'icon'
+		'icon',
+		'remoteBranch',
+		'existingBranch'
 	],
 	#category : 'Iceberg-TipUI-View-Branch',
 	#package : 'Iceberg-TipUI',
 	#tag : 'View-Branch'
 }
+
+{ #category : 'actions' }
+IceTipCancelBranchPanel >> accept [
+
+	self executeFor: remoteBranch localBranch: existingBranch inRepository: self repository
+]
 
 { #category : 'layout' }
 IceTipCancelBranchPanel >> defaultLayout [
@@ -17,16 +28,34 @@ IceTipCancelBranchPanel >> defaultLayout [
 ]
 
 { #category : 'action' }
-IceTipCancelBranchPanel >> executeFor: remoteBranch localBranch: localBranch inRepository: aRepository [
+IceTipCancelBranchPanel >> executeFor: aRemoteBranch localBranch: aLocalBranch inRepository: aRepository [
 	"Return nil to indicate cancellation"
 
 	^ nil
 ]
 
 { #category : 'accessing' }
+IceTipCancelBranchPanel >> existingBranch: aBranch [
+
+	existingBranch := aBranch 
+]
+
+{ #category : 'accessing' }
 IceTipCancelBranchPanel >> icon [
 
 	^ self iconNamed: #cancel
+]
+
+{ #category : 'accessing' }
+IceTipCancelBranchPanel >> remoteBranch: aRemoteBranch [
+
+	remoteBranch := aRemoteBranch
+]
+
+{ #category : 'accessing' }
+IceTipCancelBranchPanel >> repository [
+
+	^ self model repository
 ]
 
 { #category : 'initialization' }

--- a/Iceberg-TipUI/IceTipCancelBranchPanel.class.st
+++ b/Iceberg-TipUI/IceTipCancelBranchPanel.class.st
@@ -10,8 +10,15 @@ Class {
 	#tag : 'View-Branch'
 }
 
-{ #category : 'actions' }
-IceTipCancelBranchPanel >> doAccept [
+{ #category : 'layout' }
+IceTipCancelBranchPanel >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight yourself
+]
+
+{ #category : 'action' }
+IceTipCancelBranchPanel >> executeFor: remoteBranch localBranch: localBranch inRepository: aRepository [
+	"Return nil to indicate cancellation"
 
 	^ nil
 ]
@@ -22,8 +29,14 @@ IceTipCancelBranchPanel >> icon [
 	^ self iconNamed: #cancel
 ]
 
+{ #category : 'initialization' }
+IceTipCancelBranchPanel >> windowIcon [
+
+	^ self icon
+]
+
 { #category : 'accessing' }
 IceTipCancelBranchPanel >> windowTitle [
 
-	^ 'Cancel'
+	^ 'Cancel checkout operation'
 ]

--- a/Iceberg-TipUI/IceTipCancelBranchPanel.class.st
+++ b/Iceberg-TipUI/IceTipCancelBranchPanel.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'IceTipCancelBranchPanel',
+	#superclass : 'IceTipBranchPanel',
+	#instVars : [
+		'title',
+		'icon'
+	],
+	#category : 'Iceberg-TipUI-View-Branch',
+	#package : 'Iceberg-TipUI',
+	#tag : 'View-Branch'
+}
+
+{ #category : 'actions' }
+IceTipCancelBranchPanel >> doAccept [
+
+	^ nil
+]
+
+{ #category : 'accessing' }
+IceTipCancelBranchPanel >> icon [
+
+	^ self iconNamed: #cancel
+]
+
+{ #category : 'accessing' }
+IceTipCancelBranchPanel >> windowTitle [
+
+	^ 'Cancel'
+]

--- a/Iceberg-TipUI/IceTipCheckoutBranchDialog.class.st
+++ b/Iceberg-TipUI/IceTipCheckoutBranchDialog.class.st
@@ -36,16 +36,20 @@ IceTipCheckoutBranchDialog >> allTypes [
 IceTipCheckoutBranchDialog >> createCheckoutBranchTypes [
 
 	| allTypes |
+	"Collect types new+local+remotes"	
+	allTypes :=  { 
+		IceTipCheckoutNewBranchPanel on: self model. "New branch"
+	 	(IceTipCheckoutBranchPanel on: self model) 
+			titleForWindow: 'Local';
+			icon: (self iconNamed: #branch);
+			yourself }, 
+	(self model remoteModels collect: [ :each | 
+		(IceTipCheckoutBranchPanel on: each)
+			titleForWindow: each name;
+			icon: (self iconNamed: #remote);
+			yourself ]),
+	(self model entity pluginManager checkoutBranchPanelsOnModel: self model).
 	
-		allTypes := { ((IceTipMergeBranchPanel on: self model)
-		             titleForWindow: 'Local';
-		             icon: (self iconNamed: #branch);
-		             yourself) }
-	            , (self model remoteModels collect: [ :each |
-			             (IceTipMergeBranchPanel on: each)
-				             titleForWindow: each name;
-				             icon: (self iconNamed: #remote);
-				             yourself ]).
 	"Doing this because I can trigger the accept inside the panels."
 	allTypes do: [ :each | each onAccept: [ self closeWindow ] ].
 	

--- a/Iceberg-TipUI/IceTipCheckoutBranchDialog.class.st
+++ b/Iceberg-TipUI/IceTipCheckoutBranchDialog.class.st
@@ -36,20 +36,16 @@ IceTipCheckoutBranchDialog >> allTypes [
 IceTipCheckoutBranchDialog >> createCheckoutBranchTypes [
 
 	| allTypes |
-	"Collect types new+local+remotes"	
-	allTypes :=  { 
-		IceTipCheckoutNewBranchPanel on: self model. "New branch"
-	 	(IceTipCheckoutBranchPanel on: self model) 
-			titleForWindow: 'Local';
-			icon: (self iconNamed: #branch);
-			yourself }, 
-	(self model remoteModels collect: [ :each | 
-		(IceTipCheckoutBranchPanel on: each)
-			titleForWindow: each name;
-			icon: (self iconNamed: #remote);
-			yourself ]),
-	(self model entity pluginManager checkoutBranchPanelsOnModel: self model).
 	
+		allTypes := { ((IceTipMergeBranchPanel on: self model)
+		             titleForWindow: 'Local';
+		             icon: (self iconNamed: #branch);
+		             yourself) }
+	            , (self model remoteModels collect: [ :each |
+			             (IceTipMergeBranchPanel on: each)
+				             titleForWindow: each name;
+				             icon: (self iconNamed: #remote);
+				             yourself ]).
 	"Doing this because I can trigger the accept inside the panels."
 	allTypes do: [ :each | each onAccept: [ self closeWindow ] ].
 	

--- a/Iceberg-TipUI/IceTipConflictCheckoutAsNewPanel.class.st
+++ b/Iceberg-TipUI/IceTipConflictCheckoutAsNewPanel.class.st
@@ -1,0 +1,63 @@
+"
+I'm a panel to checkout a remote as a new branch.
+"
+Class {
+	#name : 'IceTipConflictCheckoutAsNewPanel',
+	#superclass : 'IceTipCheckoutNewBranchPanel',
+	#instVars : [
+		'title',
+		'icon',
+		'existingBranch',
+		'remoteBranch'
+	],
+	#category : 'Iceberg-TipUI-View-Branch',
+	#package : 'Iceberg-TipUI',
+	#tag : 'View-Branch'
+}
+
+{ #category : 'actions' }
+IceTipConflictCheckoutAsNewPanel >> accept [
+
+	self executeFor: remoteBranch localBranch: existingBranch inRepository: self repository
+]
+
+{ #category : 'action' }
+IceTipConflictCheckoutAsNewPanel >> executeFor: aRemoteBranch localBranch: aLocalBranch inRepository: aRepository [
+
+	| newBranch |
+	
+	self validate.
+	newBranch := aRepository createBranch: self branchName inCommit: remoteBranch commit.
+
+	^ newBranch
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutAsNewPanel >> existingBranch: aBranch [
+
+	existingBranch := aBranch
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutAsNewPanel >> icon [
+
+	^ self iconNamed: #smallNew
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutAsNewPanel >> remoteBranch: aRemoteBranch [
+
+	remoteBranch := aRemoteBranch
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutAsNewPanel >> repository [
+
+	^ self model repository
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutAsNewPanel >> windowTitle [
+
+	^ 'Checkout remote as new branch'
+]

--- a/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
+++ b/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
@@ -28,8 +28,7 @@ IceTipConflictCheckoutReplaceLocalPanel >> confirmDeletionOf: aBranch [
 		  title: 'Confirm Destructive Action';
 		  message: ('Are you sure you want to delete the local branch "{1}"?
 This action cannot be undone and you may LOSE CODE!' format: { aBranch name });
-		  openModal;
-		  yourself
+		  openModal
 ]
 
 { #category : 'layout' }
@@ -55,22 +54,25 @@ Only use this option if you are certain that:
 { #category : 'action' }
 IceTipConflictCheckoutReplaceLocalPanel >> executeFor: aRemoteBranch localBranch: aLocalBranch inRepository: aRepository [
 
-	self validate "
-	(self hasUncommittedChangesIn: localBranch)
-		ifTrue: [ 
+	self validate.
+	(self hasUncommittedChangesIn: aLocalBranch) ifTrue: [
 			IceError signal: 'Cannot delete local branch: it has uncommitted changes.
 Please commit or discard changes before proceeding.' ].
 
-	localBranch delete.
-	^ remoteBranch repository
-		createBranch: remoteBranch shortName
-		inCommit: remoteBranch commit"
+	aLocalBranch delete.
+	^ remoteBranch repository createBranch: remoteBranch shortName inCommit: remoteBranch commit
 ]
 
 { #category : 'accessing' }
 IceTipConflictCheckoutReplaceLocalPanel >> existingBranch: aBranch [
 
 	existingBranch := aBranch
+]
+
+{ #category : 'testing' }
+IceTipConflictCheckoutReplaceLocalPanel >> hasUncommittedChangesIn: aBranch [
+
+	^ aBranch repository workingCopy notNil and: [ aBranch repository workingCopy isModified ]
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
+++ b/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
@@ -54,7 +54,7 @@ IceTipConflictCheckoutReplaceLocalPanel >> defaultLayout [
 { #category : 'accessing' }
 IceTipConflictCheckoutReplaceLocalPanel >> descriptionText [
 
-	^ 'This will DELETE your local branch and replace it with the remote version.
+	^ 'This will reset your local branch and replace it with the remote version.
 
 Any uncommitted changes or commits in the local branch that have not been pushed will be lost.
 
@@ -71,8 +71,8 @@ IceTipConflictCheckoutReplaceLocalPanel >> executeFor: aRemoteBranch localBranch
 			(self confirmDiscardChanges: aLocalBranch) ifFalse: [ ^ nil ].
 			aLocalBranch repository workingCopy discardChanges ].
 
-	aLocalBranch delete.
-	^ remoteBranch repository createBranch: remoteBranch shortName inCommit: remoteBranch commit
+	aLocalBranch commit: remoteBranch commit.
+	^ aLocalBranch
 ]
 
 { #category : 'accessing' }

--- a/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
+++ b/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
@@ -26,7 +26,7 @@ IceTipConflictCheckoutReplaceLocalPanel >> confirmDeletionOf: aBranch [
 
 	^ SpConfirmDialog new
 		  title: 'Confirm Destructive Action';
-		  message: ('Are you sure you want to delete the local branch "{1}"?
+		  label: ('Are you sure you want to delete the local branch "{1}"?
 This action cannot be undone and you may LOSE CODE!' format: { aBranch name });
 		  openModal
 ]

--- a/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
+++ b/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
@@ -1,0 +1,110 @@
+"
+I'm a panel to remove a local branch that has the same name as the remote branch to checkout it.
+"
+Class {
+	#name : 'IceTipConflictCheckoutReplaceLocalPanel',
+	#superclass : 'IceTipBranchPanel',
+	#instVars : [
+		'title',
+		'icon',
+		'remoteBranch',
+		'existingBranch'
+	],
+	#category : 'Iceberg-TipUI-View-Branch',
+	#package : 'Iceberg-TipUI',
+	#tag : 'View-Branch'
+}
+
+{ #category : 'actions' }
+IceTipConflictCheckoutReplaceLocalPanel >> accept [
+
+	self executeFor: remoteBranch localBranch: existingBranch inRepository: self repository
+]
+
+{ #category : 'ui - dialogs' }
+IceTipConflictCheckoutReplaceLocalPanel >> confirmDeletionOf: aBranch [
+
+	^ SpConfirmDialog new
+		  title: 'Confirm Destructive Action';
+		  message: ('Are you sure you want to delete the local branch "{1}"?
+This action cannot be undone and you may LOSE CODE!' format: { aBranch name });
+		  openModal;
+		  yourself
+]
+
+{ #category : 'layout' }
+IceTipConflictCheckoutReplaceLocalPanel >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight yourself
+		  add: self descriptionText expand: true;
+		  yourself
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutReplaceLocalPanel >> descriptionText [
+
+	^ 'This will DELETE your local branch and replace it with the remote version.
+
+Any uncommitted changes or commits in the local branch that have not been pushed will be lost.
+
+Only use this option if you are certain that:
+- The local branch is no longer needed
+- All important work has been saved elsewhere'
+]
+
+{ #category : 'action' }
+IceTipConflictCheckoutReplaceLocalPanel >> executeFor: aRemoteBranch localBranch: aLocalBranch inRepository: aRepository [
+
+	self validate "
+	(self hasUncommittedChangesIn: localBranch)
+		ifTrue: [ 
+			IceError signal: 'Cannot delete local branch: it has uncommitted changes.
+Please commit or discard changes before proceeding.' ].
+
+	localBranch delete.
+	^ remoteBranch repository
+		createBranch: remoteBranch shortName
+		inCommit: remoteBranch commit"
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutReplaceLocalPanel >> existingBranch: aBranch [
+
+	existingBranch := aBranch
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutReplaceLocalPanel >> icon [
+
+	^ self iconNamed: #smallWarning
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutReplaceLocalPanel >> remoteBranch: aRemoteBranch [
+
+	remoteBranch := aRemoteBranch
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutReplaceLocalPanel >> repository [
+
+	^ self model repository
+]
+
+{ #category : 'accessing' }
+IceTipConflictCheckoutReplaceLocalPanel >> validate [
+
+	(self confirmDeletionOf: existingBranch) ifFalse: [ ^ nil ]
+]
+
+{ #category : 'initialization' }
+IceTipConflictCheckoutReplaceLocalPanel >> windowIcon [
+
+	^ self icon
+]
+
+{ #category : 'initialization' }
+IceTipConflictCheckoutReplaceLocalPanel >> windowTitle [
+
+	^ 'Delete local branch and checkout remote (DANGEROUS)'
+]

--- a/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
+++ b/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
@@ -31,6 +31,18 @@ This action cannot be undone and you may LOSE CODE!' format: { aBranch name });
 		  openModal
 ]
 
+{ #category : 'ui - dialogs' }
+IceTipConflictCheckoutReplaceLocalPanel >> confirmDiscardChanges: aBranch [
+
+	^ SpConfirmDialog new
+		  title: 'Uncommitted Changes Detected';
+		  message: ('Branch "{1}" has uncommitted changes.
+
+Do you want to discard all changes and continue?' format: { aBranch name });
+		  acceptLabel: 'Discard changes';
+		  openModal
+]
+
 { #category : 'layout' }
 IceTipConflictCheckoutReplaceLocalPanel >> defaultLayout [
 
@@ -56,8 +68,8 @@ IceTipConflictCheckoutReplaceLocalPanel >> executeFor: aRemoteBranch localBranch
 
 	self validate.
 	(self hasUncommittedChangesIn: aLocalBranch) ifTrue: [
-			IceError signal: 'Cannot delete local branch: it has uncommitted changes.
-Please commit or discard changes before proceeding.' ].
+			(self confirmDiscardChanges: aLocalBranch) ifFalse: [ ^ nil ].
+			aLocalBranch repository workingCopy discardChanges ].
 
 	aLocalBranch delete.
 	^ remoteBranch repository createBranch: remoteBranch shortName inCommit: remoteBranch commit

--- a/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
+++ b/Iceberg-TipUI/IceTipConflictCheckoutReplaceLocalPanel.class.st
@@ -54,13 +54,14 @@ IceTipConflictCheckoutReplaceLocalPanel >> defaultLayout [
 { #category : 'accessing' }
 IceTipConflictCheckoutReplaceLocalPanel >> descriptionText [
 
-	^ 'This will reset your local branch and replace it with the remote version.
-
-Any uncommitted changes or commits in the local branch that have not been pushed will be lost.
-
-Only use this option if you are certain that:
-- The local branch is no longer needed
-- All important work has been saved elsewhere'
+	^ SpBoxLayout newTopToBottom
+		  add: (self newLabel label: 'This will reset your local branch and replace it with the remote version.') expand: false;
+		  add: (self newLabel label: 'Any uncommitted changes or commits in the local branch that have not been pushed will be lost.')
+		  expand: false;
+		  add: (self newLabel label: 'Only use this option if you are certain that:') expand: false;
+		  add: (self newLabel label: '- The local branch is no longer needed') expand: false;
+		  add: (self newLabel label: '- All important work has been saved elsewhere') expand: false;
+		  yourself
 ]
 
 { #category : 'action' }
@@ -117,8 +118,8 @@ IceTipConflictCheckoutReplaceLocalPanel >> windowIcon [
 	^ self icon
 ]
 
-{ #category : 'initialization' }
+{ #category : 'accessing' }
 IceTipConflictCheckoutReplaceLocalPanel >> windowTitle [
 
-	^ 'Delete local branch and checkout remote (DANGEROUS)'
+	^ 'Reset local branch to remote commit (DANGEROUS)'
 ]

--- a/Iceberg/IceBranchAlreadyExistsError.class.st
+++ b/Iceberg/IceBranchAlreadyExistsError.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'IceBranchAlreadyExists',
+	#name : 'IceBranchAlreadyExistsError',
 	#superclass : 'IceError',
 	#instVars : [
 		'branchName'
@@ -10,13 +10,13 @@ Class {
 }
 
 { #category : 'accessing' }
-IceBranchAlreadyExists >> branchName [
+IceBranchAlreadyExistsError >> branchName [
 
 	^ branchName
 ]
 
 { #category : 'accessing' }
-IceBranchAlreadyExists >> branchName: aBranchName [
+IceBranchAlreadyExistsError >> branchName: anObject [
 
-	branchName := aBranchName
+	branchName := anObject
 ]

--- a/Iceberg/IceRemoteBranch.class.st
+++ b/Iceberg/IceRemoteBranch.class.st
@@ -26,11 +26,9 @@ IceRemoteBranch >> = aBranch [
 IceRemoteBranch >> checkout: aCheckoutStrategy [
 
 	| localBranch |
-
 	self repository
 		branchNamed: self shortName
-		ifPresent: [ :existingBranch | 
-		localBranch := self handleBranchConflictWith: existingBranch ]
+		ifPresent: [ :existingBranch | localBranch := self handleBranchConflictWith: existingBranch ]
 		ifAbsent: [ localBranch := self repository createBranch: self shortName inCommit: self commit ].
 
 	localBranch ifNil: [ ^ nil ].
@@ -59,7 +57,8 @@ IceRemoteBranch >> checkoutWithStrategy: aCheckoutStrategy [
 { #category : 'handling' }
 IceRemoteBranch >> handleBranchConflictWith: existingBranch [
 
-	(IceTipBranchConflictResolutionDialog onRepository: self repository existingBranch: existingBranch) asDialogWindow open 
+	1 halt.
+	(IceTipBranchConflictResolutionDialog onRepository: self repository existingBranch: existingBranch) asDialogWindow open
 ]
 
 { #category : 'comparing' }

--- a/Iceberg/IceRemoteBranch.class.st
+++ b/Iceberg/IceRemoteBranch.class.st
@@ -26,6 +26,7 @@ IceRemoteBranch >> = aBranch [
 IceRemoteBranch >> checkout: aCheckoutStrategy [
 
 	| localBranch |
+
 	self repository
 		branchNamed: self shortName
 		ifPresent: [ :existingBranch | localBranch := self handleBranchConflictWith: existingBranch ]
@@ -57,8 +58,11 @@ IceRemoteBranch >> checkoutWithStrategy: aCheckoutStrategy [
 { #category : 'handling' }
 IceRemoteBranch >> handleBranchConflictWith: existingBranch [
 
-	1 halt.
-	(IceTipBranchConflictResolutionDialog onRepository: self repository existingBranch: existingBranch) asDialogWindow open
+	| dialog |
+	dialog := IceTipBranchConflictResolutionDialog onRepository: self repository remoteBranch: self existingBranch: existingBranch.
+	dialog openModal.
+
+	^ dialog resultBranch
 ]
 
 { #category : 'comparing' }

--- a/Iceberg/IceRemoteBranch.class.st
+++ b/Iceberg/IceRemoteBranch.class.st
@@ -26,13 +26,14 @@ IceRemoteBranch >> = aBranch [
 IceRemoteBranch >> checkout: aCheckoutStrategy [
 
 	| localBranch |
-	self repository 
+
+	self repository
 		branchNamed: self shortName
-		ifPresent: [ :branch | IceError signal: ('Branch {1} already exists' format: { self shortName }) ].
-	
-	localBranch := self repository
-		createBranch: self shortName
-		inCommit: self commit.
+		ifPresent: [ :existingBranch | 
+		localBranch := self handleBranchConflictWith: existingBranch ]
+		ifAbsent: [ localBranch := self repository createBranch: self shortName inCommit: self commit ].
+
+	localBranch ifNil: [ ^ nil ].
 
 	aCheckoutStrategy committish: localBranch.
 	^ localBranch checkout: aCheckoutStrategy
@@ -53,6 +54,12 @@ IceRemoteBranch >> checkoutWithStrategy: aCheckoutStrategy [
 		inCommit: self commit.
 	"then we can do the checkout"
 	^ super checkoutWithStrategy: aCheckoutStrategy
+]
+
+{ #category : 'handling' }
+IceRemoteBranch >> handleBranchConflictWith: existingBranch [
+
+	(IceTipBranchConflictResolutionDialog onRepository: self repository) asDialogWindow open
 ]
 
 { #category : 'comparing' }

--- a/Iceberg/IceRemoteBranch.class.st
+++ b/Iceberg/IceRemoteBranch.class.st
@@ -59,7 +59,7 @@ IceRemoteBranch >> checkoutWithStrategy: aCheckoutStrategy [
 { #category : 'handling' }
 IceRemoteBranch >> handleBranchConflictWith: existingBranch [
 
-	(IceTipBranchConflictResolutionDialog onRepository: self repository) asDialogWindow open
+	(IceTipBranchConflictResolutionDialog onRepository: self repository existingBranch: existingBranch) asDialogWindow open 
 ]
 
 { #category : 'comparing' }

--- a/Iceberg/MCPatcher.extension.st
+++ b/Iceberg/MCPatcher.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'MCPatcher' }
-
-{ #category : '*Iceberg' }
-MCPatcher >> definitions [
-	^ definitions
-]

--- a/Iceberg/MCWorkingCopy.extension.st
+++ b/Iceberg/MCWorkingCopy.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'MCWorkingCopy' }
-
-{ #category : '*Iceberg' }
-MCWorkingCopy >> info [
-	^ self versionInfo
-]


### PR DESCRIPTION
For a user when checking out a remote that exists in local, it aborted right away.
If he wanted to do so he had to checkout other branch, then delete the local and checkout the remote.
Instead of aborting it, this fix adds repair actions such as : 
- Cancel the checkout
- Checkout the remote as new branch
- Checkout anyway and delete the local branch ( and accept the risk to lose code ).
Indeed this fix brings more practicity for this kind of need.
Fixes [#18930](https://github.com/pharo-project/pharo/issues/18930#issuecomment-3562396021)
Fixes https://github.com/pharo-vcs/iceberg/issues/1095

