### PR TITLE
Remove last usages of `initialization-release` protocol

### DIFF
--- a/Iceberg-Libgit/IceLibgitCommitWalk.class.st
+++ b/Iceberg-Libgit/IceLibgitCommitWalk.class.st
@@ -13,7 +13,7 @@ Class {
 	#tag : 'Core'
 }
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 IceLibgitCommitWalk >> close [
 
 	revwalk free.

--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -298,7 +298,7 @@ and the original repository''s url is {3}.'
 					 format: {self location. self origin. repo origin}) ]].
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 IceLibgitRepository >> close [
 	
 	handle ifNil: [ ^self ].

--- a/Iceberg/IceAbstractCommitWalk.class.st
+++ b/Iceberg/IceAbstractCommitWalk.class.st
@@ -25,7 +25,7 @@ IceAbstractCommitWalk class >> isAbstract [
 	^ self == IceAbstractCommitWalk 
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 IceAbstractCommitWalk >> close [
 
 	self subclassResponsibility 


### PR DESCRIPTION
It's now a convention to use `initialization` instead of this one and Iceberg is the last project in Pharo to have those protocols. Let's remove them to not suggest this protocol anymore in the list of protocols

Part of https://github.com/pharo-project/pharo/issues/17623