### PR TITLE
ignoreNotImplementedSelectors: in iceberg

### DIFF
--- a/Iceberg-TipUI/IceTipHiedraAltComponentHistoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipHiedraAltComponentHistoryBrowser.class.st
@@ -75,7 +75,8 @@ IceTipHiedraAltComponentHistoryBrowser >> initializePresenters [
 { #category : 'initialization' }
 IceTipHiedraAltComponentHistoryBrowser >> newCommitRow: index commit: item [ 
 	
-	^ self 
+	<ignoreNotImplementedSelectors: #( formAtRow: )>
+	^ self
 		instantiate: IceTipHiedraAltHistoryRowPresenter 
 		on: { (hiedraColumnController formAtRow: index). item }
 ]

--- a/Iceberg-TipUI/IceTipHiedraAltHistoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipHiedraAltHistoryBrowser.class.st
@@ -29,6 +29,7 @@ IceTipHiedraAltHistoryBrowser >> contextMenuCommands [
 { #category : 'initialization' }
 IceTipHiedraAltHistoryBrowser >> initializeCommitList [
 
+	<ignoreNotImplementedSelectors: #( formAtRow: )>
 	commitList
 		beResizable;
 		addColumn: (SpCompositeTableColumn new
@@ -106,6 +107,7 @@ IceTipHiedraAltHistoryBrowser >> initializePresenters [
 { #category : 'initialization' }
 IceTipHiedraAltHistoryBrowser >> newCommitRow: index commit: item [ 
 	
+	<ignoreNotImplementedSelectors: #( formAtRow: )>
 	^ self 
 		instantiate: IceTipHiedraAltHistoryRowPresenter 
 		on: { (hiedraColumnController formAtRow: index). item }

--- a/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
+++ b/Iceberg-TipUI/IceTipInteractiveErrorVisitor.class.st
@@ -190,10 +190,8 @@ IceTipInteractiveErrorVisitor >> visitRemoteDesynchronizedError: anError [
 
 	| continue command |
 	continue := context application newConfirm
-		            label:
-			            ('Your repository is out of sync with remote {1}. 
-You need to pull remote changes before continue and push your changes.'
-				             format: { anError remote }); 
+		            message: ('Your repository is out of sync with remote {1}. 
+You need to pull remote changes before continue and push your changes.' format: { anError remote });
 		            title: 'Remote repository out of sync!';
 		            acceptLabel: 'Pull';
 		            cancelLabel: 'Cancel';
@@ -208,10 +206,10 @@ You need to pull remote changes before continue and push your changes.'
 	[ command executeWithContext: context ]
 		on: IceMergeAborted , IceShouldCommitBeforePull
 		do: [ :e |
-			self flag: #pharoTodo. "Refactor this"
-			(e isKindOf: IceShouldCommitBeforePull)
-				ifTrue: [ e resume ]
-				ifFalse: [ e acceptError: self ] ].
+				self flag: #pharoTodo. "Refactor this"
+				(e isKindOf: IceShouldCommitBeforePull)
+					ifTrue: [ e resume ]
+					ifFalse: [ e acceptError: self ] ].
 
 	command isSuccess ifFalse: [ ^ self ].
 	anError isResumable ifTrue: [ ^ anError resume ].


### PR DESCRIPTION
To simplify release tests.

This shows potentially broken code.