### PR TITLE
when collecting method history you just need one, not all parents

### DIFF
--- a/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
+++ b/Iceberg-TipUI/IceTipWorkingCopyBrowser.class.st
@@ -178,11 +178,10 @@ IceTipWorkingCopyBrowser >> initializePresenters [
 
 { #category : 'initialization' }
 IceTipWorkingCopyBrowser >> initializeWindow: aSpWindowPresenter [
-	
+
 	super initializeWindow: aSpWindowPresenter.
 
-	aSpWindowPresenter statusBar: statusBar.
-
+	aSpWindowPresenter statusbar: statusBar
 ]
 
 { #category : 'accessing - ui' }

--- a/Iceberg/IceConflictingOperation.class.st
+++ b/Iceberg/IceConflictingOperation.class.st
@@ -98,6 +98,18 @@ IceConflictingOperation >> leftContents [
 ]
 
 { #category : 'accessing' }
+IceConflictingOperation >> leftDefinition [
+
+	^ self definition
+]
+
+{ #category : 'accessing' }
+IceConflictingOperation >> leftOperation [
+	
+	^ leftOperation
+]
+
+{ #category : 'accessing' }
 IceConflictingOperation >> leftOperation: anOperation [
 	
 	leftOperation := anOperation
@@ -110,9 +122,21 @@ IceConflictingOperation >> rightContents [
 ]
 
 { #category : 'accessing' }
+IceConflictingOperation >> rightOperation [
+	
+	^ rightOperation
+]
+
+{ #category : 'accessing' }
 IceConflictingOperation >> rightOperation: anOperation [
 	
 	rightOperation := anOperation
+]
+
+{ #category : 'accessing' }
+IceConflictingOperation >> rigthDefinition [
+
+	^ rightOperation definition
 ]
 
 { #category : 'resolution' }

--- a/Iceberg/IceLog.class.st
+++ b/Iceberg/IceLog.class.st
@@ -55,17 +55,18 @@ IceLog >> collectCommitsFor: aMethod path: aPath [
 		walk 
 			fromCommit: commit;
 			rawResultsDo: [ :eachCommit | | parents tree | 
-				parents := eachCommit numberOfParents.
 				tree := eachCommit tree.
+				parents := eachCommit numberOfParents.
 				parents = 0 
 					ifTrue: [
 						(tree matchesPathSpec: pathSpec)
 							ifTrue: [ commits add: eachCommit ] ]
 					ifFalse: [ 
-						eachCommit parents do: [ :eachParent | | diff |
-							diff := tree diffTo: eachParent tree options: options. 
-							diff numberOfDeltas > 0 
-								ifTrue: [ commits add: eachCommit ] ] ] ]].
+						| diff parent |
+						parent := eachCommit parents first.
+						diff := tree diffTo: parent tree options: options. 
+						diff numberOfDeltas > 0 
+							ifTrue: [ commits add: eachCommit ] ] ] ].
 
 	^ commits
 ]

--- a/Iceberg/IceOperationMerge.class.st
+++ b/Iceberg/IceOperationMerge.class.st
@@ -78,6 +78,12 @@ IceOperationMerge >> isLoadable [
 ]
 
 { #category : 'testing' }
+IceOperationMerge >> isNoModification [
+
+	^ false
+]
+
+{ #category : 'testing' }
 IceOperationMerge >> isResolved [
 	
 	^ chosen isNotNil


### PR DESCRIPTION
while collecting the history, is enough to traverse just the first parent.
and it speeds up slightly the process. 