### PR TITLE
Improve the short commit ID

### DIFF
--- a/Iceberg-TipUI/IceTipReadOnlyFormBuilder.class.st
+++ b/Iceberg-TipUI/IceTipReadOnlyFormBuilder.class.st
@@ -50,7 +50,7 @@ IceTipReadOnlyFormBuilder >> application: aSpApplication [
 { #category : 'building' }
 IceTipReadOnlyFormBuilder >> build [
 
-	presenter := spApplication newPresenter: SpPresenter.
+	presenter := spApplication instantiate: SpPresenter.
 	presenter layout: self buildLayout.
 	^ presenter
 ]

--- a/Iceberg-TipUI/IceTipRepositoryModel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryModel.class.st
@@ -426,7 +426,11 @@ IceTipRepositoryModel >> repositoryModelsByGroup [
 
 { #category : 'accessing' }
 IceTipRepositoryModel >> shortCommitId [
-	^ [self entity headCommit shortId] on: Error do: [ nil ].
+	"Return the short commit id of the commit loaded in Pharo. Be careful, this does not return the commit of the working copy if the head is detached."
+
+	^ [ self commit shortId ]
+		  on: Error
+		  do: [ nil ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
The short commit id was the one of the local repository.  Now I return the one loaded in Pharo. This is better because it allows to display the commit of a deteched working copy or of a repository without local sources. 

This will be useful since there is a PR to display the commit in Iceberg