### PR TITLE
fix create tag on repositories browser

### DIFF
--- a/Iceberg-TipUI/IceTipRepositoryGroupPanel.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryGroupPanel.class.st
@@ -209,6 +209,12 @@ IceTipRepositoryGroupPanel >> refreshRepositoryList [
 
 ]
 
+{ #category : 'api' }
+IceTipRepositoryGroupPanel >> refreshTags [
+	
+	self refreshRepositoryList
+]
+
 { #category : 'accessing' }
 IceTipRepositoryGroupPanel >> repositoryList [
 


### PR DESCRIPTION
Refreshing repositories because we may have some information to show.