### PR TITLE
correcting grayed out commit button

### DIFF
--- a/Iceberg-TipUI/IceTipCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCommitBrowser.class.st
@@ -105,7 +105,7 @@ IceTipCommitBrowser >> doCollapseSelection [
 { #category : 'actions' }
 IceTipCommitBrowser >> doCommit [
 
-	| selectedItems message isPushing isSaving commitBlock |
+	| selectedItems message isPushing isSaving commitBlock cancelBlock |
 	selectedItems := diffPanel selectedItems.
 	message := commentPanel message.
 	isPushing := commentPanel isPushing.
@@ -117,12 +117,14 @@ IceTipCommitBrowser >> doCommit [
 			               message: message
 			               pushing: isPushing
 			               saving: isSaving ].
+	cancelBlock := [ self commentPanel commitButton enabled: true ].
 
 	(IceTipCritiquesBeforeCommitBrowser
 		 onApplication: self application
 		 model: selectedItems
 		 commitModel: self model
-		 acceptBlock: commitBlock) openIfCritiques
+		 acceptBlock: commitBlock
+		 cancelBlock: cancelBlock) openIfCritiques
 ]
 
 { #category : 'actions' }

--- a/Iceberg-TipUI/IceTipCritiquesBeforeCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCritiquesBeforeCommitBrowser.class.st
@@ -13,7 +13,8 @@ Class {
 		'reasonPanel',
 		'detailPanel',
 		'browseButton',
-		'autofixButton'
+		'autofixButton',
+		'onCancelAction'
 	],
 	#category : 'Iceberg-TipUI-View-Commit',
 	#package : 'Iceberg-TipUI',
@@ -33,13 +34,14 @@ IceTipCritiquesBeforeCommitBrowser class >> buildSelectionCommandGroupWith: pres
 ]
 
 { #category : 'commands' }
-IceTipCritiquesBeforeCommitBrowser class >> onApplication: anApplication model: aModel commitModel: aCommitModel acceptBlock: anAcceptBlock [
+IceTipCritiquesBeforeCommitBrowser class >> onApplication: anApplication model: aModel commitModel: aCommitModel acceptBlock: anAcceptBlock cancelBlock: aCancelBlock [
 
 	^ self basicNew
 		  application: anApplication;
 		  setModelBeforeInitialization: aModel;
 		  commitModel: aCommitModel;
 		  onAccept: anAcceptBlock;
+		  onCancel: aCancelBlock;
 		  initialize;
 		  yourself
 ]
@@ -67,6 +69,13 @@ IceTipCritiquesBeforeCommitBrowser >> calculateCritics [
 			calculatedCritics := visitor critiques asOrderedCollection ].
 	
 	^ calculatedCritics
+]
+
+{ #category : 'actions' }
+IceTipCritiquesBeforeCommitBrowser >> cancel [
+
+	self closeWindow.
+	onCancelAction value
 ]
 
 { #category : 'accessing' }
@@ -238,6 +247,12 @@ IceTipCritiquesBeforeCommitBrowser >> model [
 IceTipCritiquesBeforeCommitBrowser >> onAccept: aFullBlockClosure [ 
 	
 	onAcceptAction := aFullBlockClosure 
+]
+
+{ #category : 'accessing' }
+IceTipCritiquesBeforeCommitBrowser >> onCancel: aFullBlockClosure [ 
+	
+	onCancelAction := aFullBlockClosure 
 ]
 
 { #category : 'actions' }

--- a/Iceberg/IceSystemEventListener.class.st
+++ b/Iceberg/IceSystemEventListener.class.st
@@ -26,6 +26,15 @@ IceSystemEventListener class >> handleMethodChange: aMethodChange [
 	self handlePackagesChange: aMethodChange packagesAffected
 ]
 
+{ #category : 'system annoucements' }
+IceSystemEventListener class >> handleMethodModified: aMethodChange [
+	
+	|oldMethod methodAfter|
+	oldMethod := aMethodChange oldMethod .
+	methodAfter := aMethodChange methodAffected .
+	oldMethod sourceCode ~= methodAfter sourceCode ifTrue: [ self handlePackagesChange: aMethodChange packagesAffected ] 
+]
+
 { #category : 'event handling' }
 IceSystemEventListener class >> handlePackageChange: aPackageChange [
 
@@ -82,7 +91,11 @@ IceSystemEventListener class >> registerSystemAnnouncements [
 
 	self codeChangeAnnouncer weak
 		when: ClassAnnouncement send: #handleClassChange: to: self;
-		when: MethodAnnouncement send: #handleMethodChange: to: self;
+		when: MethodAdded send: #handleMethodChange: to: self;
+		when: MethodRecategorized send: #handleMethodChange: to: self;
+		when: MethodRemoved send: #handleMethodChange: to: self;
+		when: MethodRepackaged send: #handleMethodChange: to: self;
+		when: MethodModified send: #handleMethodModified: to: self;
 		when: PackageTagAnnouncement send: #handlePackageChange: to: self.
 
 	self codeSupportAnnouncer weak when: MCVersionLoaderStopped send: #handleVersionLoaded: to: self


### PR DESCRIPTION
Fix #2056 

We do it the same way that we manage the accept : we give the critiques browser a block with the code to enable the button. That block is evaluated when the window is canceled