### PR TITLE
Fix bug 2057 about ghost commits

### DIFF
--- a/Iceberg-TipUI/IceTipCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCommitBrowser.class.st
@@ -107,6 +107,12 @@ IceTipCommitBrowser >> doCommit [
 
 	| selectedItems message isPushing isSaving commitBlock |
 	selectedItems := diffPanel selectedItems.
+	
+	"We can't commit empty modification"
+	selectedItems isEmpty ifTrue: [ 
+		self inform: 'There is no modifications to commit.'.
+		^ self ].
+	
 	message := commentPanel message.
 	isPushing := commentPanel isPushing.
 	isSaving := commentPanel isSaving.

--- a/Iceberg-TipUI/IceTipCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCommitBrowser.class.st
@@ -56,6 +56,14 @@ IceTipCommitBrowser >> accept [
 	^ self doCommit
 ]
 
+{ #category : 'as yet unclassified' }
+IceTipCommitBrowser >> checkModifications: selectedItems ifEmpty: aBlock [
+
+    selectedItems isEmpty ifTrue: [ 
+        self inform: 'There is no modifications to commit.'.
+        aBlock value ]
+]
+
 { #category : 'accessing - ui' }
 IceTipCommitBrowser >> commentPanel [
 
@@ -109,9 +117,7 @@ IceTipCommitBrowser >> doCommit [
 	selectedItems := diffPanel selectedItems.
 	
 	"We can't commit empty modification"
-	selectedItems isEmpty ifTrue: [ 
-		self inform: 'There is no modifications to commit.'.
-		^ self ].
+	self checkModifications: selectedItems ifEmpty: [ ^ self ].
 	
 	message := commentPanel message.
 	isPushing := commentPanel isPushing.

--- a/Iceberg-TipUI/IceTipCommitBrowser.class.st
+++ b/Iceberg-TipUI/IceTipCommitBrowser.class.st
@@ -56,7 +56,7 @@ IceTipCommitBrowser >> accept [
 	^ self doCommit
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 IceTipCommitBrowser >> checkModifications: selectedItems ifEmpty: aBlock [
 
     selectedItems isEmpty ifTrue: [ 

--- a/Iceberg/IceNode.class.st
+++ b/Iceberg/IceNode.class.st
@@ -471,7 +471,7 @@ IceNode >> select: aBlock [
 		childNode select: aBlock ].
 	
 	((selectedChildren anySatisfy: [ :each | each isEmptyNode not ])
-		or: [ aBlock value: self value ])
+		or: [ self children isEmpty and: [ aBlock value: self value ]])
 			ifFalse: [ ^ IceEmptyNode new ].
 		
 	newNode := self class value: self value.


### PR DESCRIPTION
We added a guard in the method `IceTipCommitBrowser ` to block the commits that doesn't have any modifications.

We also modified the selection method from `IceNode` to avoid the node that doesn't have any childrens.

We made the fix with @stella-pas-rose

fix #2057 