### PR TITLE
Fix command Copy working copy commit id

### DIFF
--- a/Iceberg-TipUI/IceTipWorkingCopyModel.class.st
+++ b/Iceberg-TipUI/IceTipWorkingCopyModel.class.st
@@ -4,6 +4,8 @@ I'm a model to for IceWorkingCopy entries.
 Class {
 	#name : 'IceTipWorkingCopyModel',
 	#superclass : 'IceTipModel',
+	#traits : 'TIceCopyCommitId',
+	#classTraits : 'TIceCopyCommitId classTrait',
 	#instVars : [
 		'sortingStrategy',
 		'repositoryModel',
@@ -36,13 +38,8 @@ IceTipWorkingCopyModel >> branchName [
 
 { #category : 'accessing' }
 IceTipWorkingCopyModel >> commitId [
-	^ repositoryModel commitId
-]
 
-{ #category : 'operations' }
-IceTipWorkingCopyModel >> copyCommitIDToClipboard [
-	
-	repositoryModel copyCommitIDToClipboard
+	^ self shortCommitId
 ]
 
 { #category : 'API - changes' }


### PR DESCRIPTION
The working copy window shows the working copy commit but was (trying to) copy HEAD.

Moreover, if HEAD was not available (e.g., repo not cloned) it failed with an exception.